### PR TITLE
add authorization_id in oauth response

### DIFF
--- a/hm-oauth-rest-v1.yml
+++ b/hm-oauth-rest-v1.yml
@@ -57,6 +57,9 @@ definitions:
       expires_in:
         type: integer
         description: Expiration time in seconds
+      authorization_id:
+        type: string
+        description: Authorization Id could be used later on in authorization_changed Webhook
       access_token:
         type: string
         description: Access token


### PR DESCRIPTION
`authorization_id` could be used later in authorization_changed Webhook to get update about the status of consent 