### PR TITLE
remove redundant  param in  create fleet access token api

### DIFF
--- a/hm-service-account-api-rest-v1.yml
+++ b/hm-service-account-api-rest-v1.yml
@@ -502,21 +502,12 @@ definitions:
   FleetAccessTokensRequest:
     type: object
     properties:
-      oem:
-        type: string
-        enum:
-          - bmw
-          - mini
-          - daimler_fleet
-        description: The OEM of the vehicle to ask for access to. For now only Mercedes-Benz, BMW and MINI are supported for fleet vehicles.
       vin:
         type: string
         description: The VIN of the vehicle to ask access to.
     example:
-      oem: bmw
       vin: WBADT43452G296403
     required:
-      - oem
       - vin
   AccessTokensError:
     type: object


### PR DESCRIPTION
 Users of this Api first has to call `add vehicle` API and provides brands therefore we don't need to ask for oem/brand for the second time in this api

The PR for backend change is already created. We are just working on some test coverage and will deploy the change soon.
