### PR TITLE
Update fleet api specs

### DIFF
--- a/hm-service-account-api-rest-v1.yml
+++ b/hm-service-account-api-rest-v1.yml
@@ -227,11 +227,29 @@ paths:
         '422':
           schema:
             $ref: '#/definitions/FleetErrors'
-          description: Error
+          description: Invalid Input. It occurs when the payload is missing a params or the the application is not configured.
         '401':
           schema:
             $ref: '#/definitions/FleetErrors'
-          description: Unauthorized
+          examples:
+            auth_error:
+              errors:
+                value: 
+                  - detail: Missing or invalid authorization header.
+                    source: Authorization
+                    title: Not authorized
+          description: When an invalid ServiceAccountToken is used.          
+        '403':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          examples:
+            auth_error:
+              errors:
+                value: 
+                  - detail: This service account is not associated with a fleet.
+                    source: Authorization
+                    title: Not authorized
+          description: When the application doesn't have fleet access.
         '500':
           description: Server Errors
       parameters:
@@ -260,7 +278,25 @@ paths:
         '401':
           schema:
             $ref: '#/definitions/FleetErrors'
-          description: Unauthorized
+          examples:
+            auth_error:
+              errors:
+                value: 
+                  - detail: Missing or invalid authorization header.
+                    source: Authorization
+                    title: Not authorized
+          description: When an invalid ServiceAccountToken is used.          
+        '403':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          examples:
+            auth_error:
+              errors:
+                value: 
+                  - detail: This service account is not associated with a fleet.
+                    source: Authorization
+                    title: Not authorized
+          description: When the application doesn't have fleet access.
         '500':
           description: Server Errors
       parameters:
@@ -276,7 +312,7 @@ paths:
       security:
         - ServiceAccountToken: []
       tags:
-        - Access Token
+        - Fleet
       responses:
         '200':
           schema:
@@ -286,10 +322,28 @@ paths:
           schema:
             $ref: '#/definitions/AccessTokensError'
           description: Error
+        '401':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          examples:
+            auth_error:
+              errors:
+                value: 
+                  - detail: Missing or invalid authorization header.
+                    source: Authorization
+                    title: Not authorized
+          description: When an invalid ServiceAccountToken is used.          
         '403':
           schema:
-            $ref: '#/definitions/Errors'
-          description: Unauthorized
+            $ref: '#/definitions/FleetErrors'
+          examples:
+            auth_error:
+              errors:
+                value: 
+                  - detail: This service account is not associated with a fleet.
+                    source: Authorization
+                    title: Not authorized
+          description: When the application doesn't have fleet access.
         '500':
           description: Server Errors
       parameters:


### PR DESCRIPTION
improve the error handling for fleet api by separating: 
* 401(unauthorized) when a Service Account API token is invalid
* 403(Forbidden) when an App doesn't have fleet access.