### PR TITLE
Add _geofencing_ APIs

### DIFF
--- a/hm-service-account-api-rest-v1.yml
+++ b/hm-service-account-api-rest-v1.yml
@@ -1,11 +1,14 @@
 swagger: '2.0'
 host: sandbox.api.high-mobility.com
 securityDefinitions:
-    ServiceAccountToken :
-      type: apiKey
-      name: Authorization
-      description: This is a Bearer token. Service Account Token is a temporary token for server to service communication, find out more how to generate one at https://high-mobility.com/learn/documentation/cloud-api/service-account-api/intro/
-      in: header
+  ServiceAccountToken:
+    type: apiKey
+    name: Authorization
+    description: >-
+      This is a Bearer token. Service Account Token is a temporary token for
+      server to service communication, find out more how to generate one at
+      https://high-mobility.com/learn/documentation/cloud-api/service-account-api/intro/
+    in: header
 paths:
   /v1/telematics_status:
     post:
@@ -30,8 +33,10 @@ paths:
           schema:
             $ref: '#/definitions/TelematicsStatusRequest'
       operationId: ApiWeb.TelematicsStatusController.create
-      description: Retrieves the telematics status for a specific VIN. This can be used to find out if the vehicle has the necessary connectivity to transmit data.
-  '/v1/device_certificates/{id}':
+      description: >-
+        Retrieves the telematics status for a specific VIN. This can be used to
+        find out if the vehicle has the necessary connectivity to transmit data.
+  /v1/device_certificates/{id}:
     get:
       security:
         - ServiceAccountToken: []
@@ -158,7 +163,7 @@ paths:
           description: A Service Account Token
       operationId: ApiWeb.DeviceCertificateController.index
       description: Lists all device certificates.
-  '/v1/auth_tokens/{auth_token}':
+  /v1/auth_tokens/{auth_token}:
     delete:
       tags:
         - ServiceAccountToken
@@ -178,14 +183,14 @@ paths:
           schema:
             $ref: '#/definitions/ServiceAccountTokenResponse'
           description: Success
-        '404':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Success
         '401':
           schema:
             $ref: '#/definitions/UnauthorizedErrors'
           description: When an invalid ServiceAccountToken is used.
+        '404':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Success
         '422':
           schema:
             $ref: '#/definitions/Errors'
@@ -220,7 +225,9 @@ paths:
         '500':
           description: Server Errors
       operationId: ApiWeb.ServiceAccountTokenController.create
-      description: Creates an authorization token to be used with any of the Service Account API endpoints.
+      description: >-
+        Creates an authorization token to be used with any of the Service
+        Account API endpoints.
   /v1/fleets/vehicles:
     post:
       security:
@@ -232,10 +239,6 @@ paths:
           schema:
             $ref: '#/definitions/FleetVehiclePostResponse'
           description: Success
-        '422':
-          schema:
-            $ref: '#/definitions/FleetErrors'
-          description: Invalid Input. It occurs when the payload is missing a params or the the application is not configured.
         '401':
           schema:
             $ref: '#/definitions/UnauthorizedErrors'
@@ -244,6 +247,12 @@ paths:
           schema:
             $ref: '#/definitions/FleetFrobidenErrors'
           description: When the application doesn't have fleet access.
+        '422':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          description: >-
+            Invalid Input. It occurs when the payload is missing a params or the
+            the application is not configured.
         '500':
           description: Server Errors
       parameters:
@@ -258,7 +267,10 @@ paths:
           in: header
           description: A Service Account Token associated to a fleet application
       operationId: ApiWeb.FleetImportController.create
-      description: Register a fleet vehicle for data access clearance. Once the VIN has its status changed to "approved", an access token can be retrieved for the VIN.
+      description: >-
+        Register a fleet vehicle for data access clearance. Once the VIN has its
+        status changed to "approved", an access token can be retrieved for the
+        VIN.
     get:
       security:
         - ServiceAccountToken: []
@@ -293,7 +305,9 @@ paths:
           in: header
           description: A Service Account Token associated to a fleet application
       operationId: ApiWeb.FleetImportController.index
-      description: Get the status of VINs that have previously been registered for data access clearance.
+      description: >-
+        Get the status of VINs that have previously been registered for data
+        access clearance.
   /v1/fleets/vehicles/{vin}:
     get:
       security:
@@ -332,8 +346,15 @@ paths:
           name: Authorization
           in: header
           description: A Service Account Token associated to a fleet application
+        - type: string
+          required: true
+          name: vin
+          in: path
+          description: VIN of the vehicle in question.
       operationId: ApiWeb.FleetVehicleController.show
-      description: Get the status of a VIN that has previously been registered for data access clearance.
+      description: >-
+        Get the status of a VIN that has previously been registered for data
+        access clearance.
   /v1/fleets/{vin}/cancel_activation:
     post:
       security:
@@ -345,10 +366,6 @@ paths:
           schema:
             $ref: '#/definitions/FleetVin'
           description: Vehicle activation is being canceled.
-        '422':
-          schema:
-            $ref: '#/definitions/FleetErrors'
-          description: Invalid input. This occurs when the payload is missing a parameter or the application has not been configured.
         '401':
           schema:
             $ref: '#/definitions/UnauthorizedErrors'
@@ -361,6 +378,12 @@ paths:
           schema:
             $ref: '#/definitions/FleetErrors'
           description: Given resource not found
+        '422':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          description: >-
+            Invalid input. This occurs when the payload is missing a parameter
+            or the application has not been configured.
         '500':
           description: Server Errors
       parameters:
@@ -370,7 +393,10 @@ paths:
           in: path
           description: Vehicle identification number
       operationId: ApiWeb.FleetCancelActivationController.create
-      description: Cancel the ongoing activation process of a vehicle that has the "pending" status. Note that this endpoint does not revoke vehicles that are in the "approved" state, for which the OAuth2 API has to be used.
+      description: >-
+        Cancel the ongoing activation process of a vehicle that has the
+        "pending" status. Note that this endpoint does not revoke vehicles that
+        are in the "approved" state, for which the OAuth2 API has to be used.
   /v1/fleets/access_tokens:
     post:
       security:
@@ -414,11 +440,627 @@ paths:
           in: header
           description: A Service Account Token associated to a fleet application
       operationId: ApiWeb.FleetAccessTokenController.create
-      description: Creates an access token for a VIN that has the "approved" state. This access token can be used to retrieve car data through any of the SDKs or the REST API.
+      description: >-
+        Creates an access token for a VIN that has the "approved" state. This
+        access token can be used to retrieve car data through any of the SDKs or
+        the REST API.
+  /v1/fleets/geofences/events/{vin}:
+    get:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofences
+      summary: Get the latest events for a vehicle
+      description: >-
+        **Get** the last (up to 5) events of a vehicle with the given _VIN_.<br>
+        The events symbolize the vehicle crossing over boundaries of previously
+        configured geofences and "activating" their triggers.<br> <br> Requires
+        a previously created zone and a notification, and the vehicle to have
+        moved in way to trigger the events.
+      operationId: Fleets.Geofencing.Events.index
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+        - type: string
+          required: true
+          name: vin
+          in: path
+          description: _VIN_ of the vehicle to **fetch** the _events_ for.
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingEvents'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '404':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          description: Events not found (or empty) - invalid _VIN_.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+  /v1/fleets/geofences/notifications/{id}:
+    delete:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofences
+      summary: Delete a notification
+      description: >-
+        **Delete** the notification with the given _ID_.<br> If successful,
+        events associated with this notification are also deleted.
+      operationId: Fleets.Geofencing.Notifications.delete
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+        - type: string
+          required: true
+          name: id
+          in: path
+          description: _ID_ of the notification to be **deleted**.
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingNotificationDeleted'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '404':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          description: Notification not found - invalid _ID_.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+    get:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofences
+      summary: Get a single notification's data
+      description: >-
+        **Get** the data for a specific notification with the given _ID_.<br>
+        The notification must be created before.
+      operationId: Fleets.Geofencing.Notifications.get
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+        - type: string
+          required: true
+          name: id
+          in: path
+          description: _ID_ of the notification to be **fetched**.
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingNotification'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '404':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          description: Notification not found - invalid _ID_.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+  /v1/fleets/geofences/notifications:
+    get:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofences
+      summary: Get all notifications' data
+      description: '**Get** the data for _all_ notifications created.'
+      operationId: Fleets.Geofencing.Notifications.index
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingNotifications'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+    post:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofences
+      summary: Create a notification
+      description: >-
+        **Create** a notification that "ties" together a _zone_ and a _vehicle_
+        to observe events based on the set _triggers_.<br> This starts the
+        observation of the vehicle's location to determine if it has crossed the
+        zone's boundary.<br> If a "boundary crossing" event has been detected, a
+        _webhook_ is delivered (configured in _developer console_).<br> <br>
+        _Prerequisities_ are an _approved_ (or _pending_) vehicle consent and a
+        created _zone_ (referenced by it's _ID_).
+      operationId: Fleets.Geofencing.Notifications.create
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+        - in: body
+          name: body
+          schema:
+            $ref: '#/definitions/GeofencingNotificationCreate'
+      responses:
+        '201':
+          schema:
+            $ref: '#/definitions/GeofencingNotificationCreated'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: >-
+            Application doesn't have fleet access.<br> Vehicle doesn't have
+            consent _approved_ or (_pending_).
+        '404':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          description: Zone not found - invalid _ID_.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+  /v1/fleets/geofences/zones/{id}:
+    delete:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofences
+      summary: Delete a zone
+      description: >-
+        **Delete** the zone with the given _ID_.<br> If successful,
+        notifications and events associated with this zone are also deleted.
+      operationId: Fleets.Geofencing.Zones.delete
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+        - type: string
+          required: true
+          name: id
+          in: path
+          description: _ID_ of the zone to be **deleted**.
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingZoneDeleted'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '404':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          description: Zone not found - invalid _ID_.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+    get:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofences
+      summary: Get a single zone's data
+      description: >-
+        **Get** the data for a specific zone with the given _ID_.<br> The zone
+        must be created before.
+      operationId: Fleets.Geofencing.Zones.get
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+        - type: string
+          required: true
+          name: id
+          in: path
+          description: _ID_ of the zone to be **fetched**.
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingZone'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '404':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          description: Zone not found - invalid _ID_.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+  /v1/fleets/geofences/zones:
+    get:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofences
+      summary: Get all zones' data
+      description: '**Get** the data for _all_ zones created.'
+      operationId: Fleets.Geofencing.Zones.index
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingZones'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+    post:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofences
+      summary: Create a zone
+      description: >-
+        **Create** a zone for geofencing based on [GeoJSON](https://geojson.org)
+        (and optional human-readable name).<br> In order for geofencing to work,
+        the _geojson_ needs to represent an _area_ (lines etc. will not produce
+        an effect).<br> <br> A created zone is a _prerequisite_ to connecting
+        vehicles with "geofencing behaviours" (aka _notifications_).
+      operationId: Fleets.Geofencing.Zones.create
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+        - in: body
+          required: true
+          name: body
+          schema:
+            $ref: '#/definitions/GeofencingZoneCreate'
+      responses:
+        '201':
+          schema:
+            $ref: '#/definitions/GeofencingZoneCreated'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
 info:
   version: '1.0'
   title: High Mobility Service Account API
 definitions:
+  GeofencingEvents:
+    type: object
+    title: Geofencing Events
+    description: List (array) of last events (up to 5) for the given _VIN_.
+    required:
+      - last_events
+      - vin
+    properties:
+      last_events:
+        type: object
+        title: Event
+        description: >-
+          The _event_ that was triggered, _when_ it was triggered and for what
+          _zone_.
+        required:
+          - event
+          - timestamp
+          - zone_id
+        properties:
+          event:
+            $ref: '#/definitions/GeofencingTrigger'
+          timestamp:
+            type: string
+            description: >-
+              Date and Time in _ISO8601_ format, for example:
+              `2018-11-06T10:20:37.094533Z`.
+          zone_id:
+            type: string
+            description: _ID_ of the zone (geojson) this event happened for.
+      vin:
+        type: string
+        description: _VIN_ of the vehicle in question.
+    example:
+      last_events:
+        - event: entered
+          timestamp: '2022-02-28T14:01:29Z'
+          zone_id: f5bb0c1f-1b22-434a-93c3-489b07b565f8
+        - event: exited
+          timestamp: '2022-02-28T15:22:64Z'
+          zone_id: f5bb0c1f-1b22-434a-93c3-489b07b565f8
+      vin: VIN11223344556677
+  GeofencingNotification:
+    type: object
+    title: Geofencing Notification
+    description: >-
+      Geofencing notification that defines _triggers_ to be observed for
+      "boundary crossing" events for a given vehicle in a zone.
+    required:
+      - id
+      - triggers
+      - vin
+      - zone_id
+    properties:
+      id:
+        type: string
+        description: _ID_ of the notification.
+      triggers:
+        type: array
+        description: List of geofencing _triggers_.
+        items:
+          $ref: '#/definitions/GeofencingTrigger'
+      vin:
+        type: string
+        description: _VIN_ of the vehicle to connect with the geofence (zone).
+      zone_id:
+        type: string
+        description: _ID_ of the zone to connect with the vehicle.
+    example:
+      id: 9390284e-cb37-40ec-a290-5ff9432716ec
+      triggers:
+        - entered
+        - exited
+      vin: VIN11223344556677
+      zone_id: f5bb0c1f-1b22-434a-93c3-489b07b565f8
+  GeofencingNotificationCreate:
+    type: object
+    title: Geofencing Notification Create
+    description: Geofencing notification _creation_ data.
+    required:
+      - triggers
+      - vin
+      - zone_id
+    properties:
+      triggers:
+        type: array
+        description: List of geofencing _triggers_.
+        items:
+          $ref: '#/definitions/GeofencingTrigger'
+      vin:
+        type: string
+        description: _VIN_ of the vehicle to connect with the geofence (zone).
+      zone_id:
+        type: string
+        description: _ID_ of the zone to connect with the vehicle.
+    example:
+      triggers:
+        - entered
+      vin: VIN11223344556677
+      zone_id: f5bb0c1f-1b22-434a-93c3-489b07b565f8
+  GeofencingNotificationCreated:
+    type: object
+    title: Geofencing Notification Created
+    description: Response data when a _notification_ was successfully **created**.
+    required:
+      - id
+    properties:
+      id:
+        type: string
+        description: _ID_ of the notification that was created.
+    example:
+      id: 9390284e-cb37-40ec-a290-5ff9432716ec
+  GeofencingNotificationDeleted:
+    type: object
+    title: Geofencing Notification Deleted
+    description: Response data when a _notification_ was successfully **deleted**.
+    required:
+      - id
+    properties:
+      id:
+        type: string
+        description: _ID_ of the notification that was deleted.
+    example:
+      id: 9390284e-cb37-40ec-a290-5ff9432716ec
+  GeofencingNotifications:
+    type: array
+    title: Geofencing Notifications
+    description: List (array) made up of _GeofencingNotification_-s
+    items:
+      $ref: '#/definitions/GeofencingNotification'
+  GeofencingTrigger:
+    type: string
+    title: Geofencing Trigger
+    description: Geofencing "boundary crossing" event type.
+    enum:
+      - entered
+      - exited
+    example: entered
+  GeofencingZone:
+    type: object
+    title: Geofencing Zone
+    description: >-
+      Geofencing zone with it's representation as _GeoJSON_ and the optional
+      human-readable name.
+    required:
+      - id
+      - geojson
+    properties:
+      id:
+        type: string
+        description: _ID_ of the zone.
+      geojson:
+        type: string
+        description: The zone (area) represented as a _GeoJSON_.
+      name:
+        type: string
+        description: _Name_ of the zone (optional).
+    example:
+      id: f5bb0c1f-1b22-434a-93c3-489b07b565f8
+      geojson: >-
+        {"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[12.974853515625,52.61138719721736],[13.222045898437498,52.37224556866933],[13.856506347656248,52.45600939264076],[13.62579345703125,52.72963909783717],[13.252258300781248,52.69136718582764],[12.974853515625,52.61138719721736]]]}}]}
+      name: crude_berlin
+  GeofencingZoneCreate:
+    type: object
+    title: Geofencing Zone Create
+    description: Geofencing zone _creation_ data.
+    required:
+      - geojson
+    properties:
+      geojson:
+        type: string
+        description: The zone represented as a _GeoJSON_.
+      name:
+        type: string
+        description: _Name_ of the zone (optional).
+    example:
+      geojson: >-
+        {"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[12.974853515625,52.61138719721736],[13.222045898437498,52.37224556866933],[13.856506347656248,52.45600939264076],[13.62579345703125,52.72963909783717],[13.252258300781248,52.69136718582764],[12.974853515625,52.61138719721736]]]}}]}
+      name: crude_berlin
+  GeofencingZoneCreated:
+    type: object
+    title: Geofencing Zone Created
+    description: Response data when a _zone_ was successfully **created**.
+    required:
+      - id
+    properties:
+      id:
+        type: string
+        description: _ID_ of the zone that was created.
+    example:
+      id: f5bb0c1f-1b22-434a-93c3-489b07b565f8
+  GeofencingZoneDeleted:
+    type: object
+    title: Geofencing Zone Deleted
+    description: Response data when a _zone_ was successfully **deleted**.
+    required:
+      - id
+    properties:
+      id:
+        type: string
+        description: _ID_ of the zone that was deleted.
+    example:
+      id: f5bb0c1f-1b22-434a-93c3-489b07b565f8
+  GeofencingZones:
+    type: array
+    title: Geofencing Zones
+    description: List (array) made up of _GeofencingZone_-s
+    items:
+      $ref: '#/definitions/GeofencingZone'
   TelematicsStatusResponse:
     type: object
     title: TelematicsStatusResponse
@@ -456,9 +1098,12 @@ definitions:
     properties:
       assertion:
         type: string
-        description: A JWT Signed with the service account key, read more at https://high-mobility.com/learn/documentation/cloud-api/service-account-api/intro/
+        description: >-
+          A JWT Signed with the service account key, read more at
+          https://high-mobility.com/learn/documentation/cloud-api/service-account-api/intro/
     example:
-      assertion: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJ2ZXIiOjEsImp0aSI6IjA3M2UxOTM1LTkwZDAtNDE0Mi05MTgzLWE4ZTAxNzNhZDJlNyIsImlzcyI6IjAxMDA4MmNjLTYzZTAtNGRmMy05ZmRhLTAzZThkOWQzN2I1OCIsImlhdCI6IjIwMTYtMTAtMDZUMTc6MDQ6MzQuNDQzNDc5KzAwOjAwIiwiYXVkIjoiaHR0cHM6Ly9hcGkuaGlnaC1tb2JpbGl0eS5jb20vYXBpL3YxIn0.MEQCIG8VHMVGJL_rAaxWEvWMoSMmxNBn9Fl46zcEP9l4fFGNAiBDr9bCzx0MLi0pDBMTg1w9ZAl6VJuxeVIC7c6o8YfxQw'
+      assertion: >-
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJ2ZXIiOjEsImp0aSI6IjA3M2UxOTM1LTkwZDAtNDE0Mi05MTgzLWE4ZTAxNzNhZDJlNyIsImlzcyI6IjAxMDA4MmNjLTYzZTAtNGRmMy05ZmRhLTAzZThkOWQzN2I1OCIsImlhdCI6IjIwMTYtMTAtMDZUMTc6MDQ6MzQuNDQzNDc5KzAwOjAwIiwiYXVkIjoiaHR0cHM6Ly9hcGkuaGlnaC1tb2JpbGl0eS5jb20vYXBpL3YxIn0.MEQCIG8VHMVGJL_rAaxWEvWMoSMmxNBn9Fl46zcEP9l4fFGNAiBDr9bCzx0MLi0pDBMTg1w9ZAl6VJuxeVIC7c6o8YfxQw
   ServiceAccountTokenResponse:
     type: object
     title: ServiceAccountToken
@@ -469,10 +1114,10 @@ definitions:
     properties:
       valid_until:
         type: string
-        description: 'When the token expires, formatted in ISO8601'
+        description: When the token expires, formatted in ISO8601
       valid_from:
         type: string
-        description: 'From when the token is valid, formatted in ISO8601'
+        description: From when the token is valid, formatted in ISO8601
       auth_token:
         type: string
         description: The authorization token
@@ -509,7 +1154,9 @@ definitions:
       public_key:
         type: string
         format: base64
-        description: The public key of the device that was generated with HMKit. The size should be 128 characters
+        description: >-
+          The public key of the device that was generated with HMKit. The size
+          should be 128 characters
       app_id:
         type: string
         description: the serial number of the application associated with the certificate
@@ -548,10 +1195,14 @@ definitions:
         description: the public key of the device certificate (base64)
       issuer_public_key:
         type: string
-        description: the public key of the Certificate Authority that has issued the certificate
+        description: >-
+          the public key of the Certificate Authority that has issued the
+          certificate
       issuer_name:
         type: string
-        description: 'the name of the Certificate Authority that has issued the certificate, which is always exve for published apps'
+        description: >-
+          the name of the Certificate Authority that has issued the certificate,
+          which is always exve for published apps
       id:
         type: integer
         description: the unique identifier of the device certificate
@@ -565,15 +1216,20 @@ definitions:
         type: string
         description: the serial number of the application associated with the certificate
     example:
-      signature: Ol8VNEQbNvb2zdaMquq+ovOvVKF9gGt8goKUuuFB0gcN4awZLTnKDXV4NsnRFV8ASxp/gJJa5NfJeFJuqbcwkA==
-      public_key: 1zxuh/pcdaz59nblzsz5e2y3vc0dufnzidcqubdpihzsjjcfcbne/dkorz6kxkecchqzfhbr1ha+yk+7/tzzzw==
-      issuer_public_key: wxj6v+kfyfncrnd4rzeody/gtytyoqgyizyksoh67buk7gohv67afe8kzpmfl/b1wjxnxqb9x4eeekwv/nfomg==
+      signature: >-
+        Ol8VNEQbNvb2zdaMquq+ovOvVKF9gGt8goKUuuFB0gcN4awZLTnKDXV4NsnRFV8ASxp/gJJa5NfJeFJuqbcwkA==
+      public_key: >-
+        1zxuh/pcdaz59nblzsz5e2y3vc0dufnzidcqubdpihzsjjcfcbne/dkorz6kxkecchqzfhbr1ha+yk+7/tzzzw==
+      issuer_public_key: >-
+        wxj6v+kfyfncrnd4rzeody/gtytyoqgyizyksoh67buk7gohv67afe8kzpmfl/b1wjxnxqb9x4eeekwv/nfomg==
       issuer_name: xvhm
       id: c11f0e15-c078-4f5c-a077-c15675fec5aa
       device_serial_number: f96705fcdca5d006ce
       device_name: my device
       app_id: a96027ee1779b53b1a9d6dfe
-    description: The Device Certificate proves that the the app has been created by a certified developer.
+    description: >-
+      The Device Certificate proves that the the app has been created by a
+      certified developer.
   AccessTokensReponse:
     type: object
     title: AccessTokensReponse
@@ -605,7 +1261,9 @@ definitions:
         description: Access token
     example:
       token_type: bearer
-      scope: diagnostics.get.mileage door_locks.get.locks windows.get.windows_positions
+      scope: >-
+        diagnostics.get.mileage door_locks.get.locks
+        windows.get.windows_positions
       refresh_token: 7f7a9be0-04c9-4202-a59f-35d55079b6ba
       expires_in: 600
       access_token: a50e89e5-093c-4727-8101-4c6e81addabe
@@ -666,20 +1324,20 @@ definitions:
         description: Vehicle list
     example:
       vehicles:
-        - vin: 'WBADT43452G296403'
-          status: 'pending'
-        - vin: 'WBADT43452G296404'
-          status: 'pending'
+        - vin: WBADT43452G296403
+          status: pending
+        - vin: WBADT43452G296404
+          status: pending
   FleetVehicleGetResponse:
     type: array
     title: FleetVehicleGetResponse
     items:
       $ref: '#/definitions/FleetVin'
     example:
-      - vin: 'WBADT43452G296403'
-        status: 'pending'
-      - vin: 'WBADT43452G296404'
-        status: 'pending'
+      - vin: WBADT43452G296403
+        status: pending
+      - vin: WBADT43452G296404
+        status: pending
   FleetVehicle:
     type: object
     title: FleetVehicle
@@ -755,13 +1413,15 @@ definitions:
           - error
           - revoked
           - rejected
-        description: An access token can be retrieved for the FleetVin if the status is "approved"
+        description: >-
+          An access token can be retrieved for the FleetVin if the status is
+          "approved"
       description:
         type: string
         description: Optional description of the VIN
     example:
-      vin: 'WBADT43452G296403'
-      status: 'pending'
+      vin: WBADT43452G296403
+      status: pending
   FleetErrors:
     type: object
     title: Errors
@@ -794,10 +1454,11 @@ definitions:
         items:
           $ref: '#/definitions/Error'
         example:
-          - detail: |
-              Missing or invalid authorization header. The token must be obtained through the service account API and sent as a header with the format "Authorization: Bearer <token>"
+          - detail: >
+              Missing or invalid authorization header. The token must be
+              obtained through the service account API and sent as a header with
+              the format "Authorization: Bearer <token>"
             source: Authorization
-
   AuthTokenUnauthorizedErrors:
     type: object
     title: Errors
@@ -808,6 +1469,8 @@ definitions:
         items:
           $ref: '#/definitions/Error'
         example:
-          - detail: Missing or invalid assertion. It must be a JWT signed with the service account key
+          - detail: >-
+              Missing or invalid assertion. It must be a JWT signed with the
+              service account key
             source: Authorization
             title: Not authorized

--- a/hm-service-account-api-rest-v1.yml
+++ b/hm-service-account-api-rest-v1.yml
@@ -444,190 +444,186 @@ paths:
         Creates an access token for a VIN that has the "approved" state. This
         access token can be used to retrieve car data through any of the SDKs or
         the REST API.
-  /v1/fleets/geofences/events/{vin}:
-    get:
-      security:
-        - ServiceAccountToken: []
-      tags:
-        - Geofences
-      summary: Get the latest events for a vehicle
-      description: >-
-        **Get** the last (up to 5) events of a vehicle with the given _VIN_.<br>
-        The events symbolize the vehicle crossing over boundaries of previously
-        configured geofences and "activating" their triggers.<br> <br> Requires
-        a previously created zone and a notification, and the vehicle to have
-        moved in way to trigger the events.
-      operationId: Fleets.Geofencing.Events.index
-      parameters:
-        - type: string
-          required: true
-          name: Authorization
-          in: header
-          description: '_Service Account_ token, in `Bearer: <token>` format.'
-        - type: string
-          required: true
-          name: vin
-          in: path
-          description: _VIN_ of the vehicle to **fetch** the _events_ for.
-      responses:
-        '200':
-          schema:
-            $ref: '#/definitions/GeofencingEvents'
-          description: Success
-        '401':
-          schema:
-            $ref: '#/definitions/UnauthorizedErrors'
-          description: Invalid _ServiceAccountToken_ is used.
-        '403':
-          schema:
-            $ref: '#/definitions/FleetFrobidenErrors'
-          description: Application doesn't have fleet access.
-        '404':
-          schema:
-            $ref: '#/definitions/FleetErrors'
-          description: Events not found (or empty) - invalid _VIN_.
-        '422':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Decoding errors
-        '500':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Server errors
-  /v1/fleets/geofences/notifications/{id}:
-    delete:
-      security:
-        - ServiceAccountToken: []
-      tags:
-        - Geofences
-      summary: Delete a notification
-      description: >-
-        **Delete** the notification with the given _ID_.<br> If successful,
-        events associated with this notification are also deleted.
-      operationId: Fleets.Geofencing.Notifications.delete
-      parameters:
-        - type: string
-          required: true
-          name: Authorization
-          in: header
-          description: '_Service Account_ token, in `Bearer: <token>` format.'
-        - type: string
-          required: true
-          name: id
-          in: path
-          description: _ID_ of the notification to be **deleted**.
-      responses:
-        '200':
-          schema:
-            $ref: '#/definitions/GeofencingNotificationDeleted'
-          description: Success
-        '401':
-          schema:
-            $ref: '#/definitions/UnauthorizedErrors'
-          description: Invalid _ServiceAccountToken_ is used.
-        '403':
-          schema:
-            $ref: '#/definitions/FleetFrobidenErrors'
-          description: Application doesn't have fleet access.
-        '404':
-          schema:
-            $ref: '#/definitions/FleetErrors'
-          description: Notification not found - invalid _ID_.
-        '422':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Decoding errors
-        '500':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Server errors
-    get:
-      security:
-        - ServiceAccountToken: []
-      tags:
-        - Geofences
-      summary: Get a single notification's data
-      description: >-
-        **Get** the data for a specific notification with the given _ID_.<br>
-        The notification must be created before.
-      operationId: Fleets.Geofencing.Notifications.get
-      parameters:
-        - type: string
-          required: true
-          name: Authorization
-          in: header
-          description: '_Service Account_ token, in `Bearer: <token>` format.'
-        - type: string
-          required: true
-          name: id
-          in: path
-          description: _ID_ of the notification to be **fetched**.
-      responses:
-        '200':
-          schema:
-            $ref: '#/definitions/GeofencingNotification'
-          description: Success
-        '401':
-          schema:
-            $ref: '#/definitions/UnauthorizedErrors'
-          description: Invalid _ServiceAccountToken_ is used.
-        '403':
-          schema:
-            $ref: '#/definitions/FleetFrobidenErrors'
-          description: Application doesn't have fleet access.
-        '404':
-          schema:
-            $ref: '#/definitions/FleetErrors'
-          description: Notification not found - invalid _ID_.
-        '422':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Decoding errors
-        '500':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Server errors
-  /v1/fleets/geofences/notifications:
-    get:
-      security:
-        - ServiceAccountToken: []
-      tags:
-        - Geofences
-      summary: Get all notifications' data
-      description: '**Get** the data for _all_ notifications created.'
-      operationId: Fleets.Geofencing.Notifications.index
-      parameters:
-        - type: string
-          required: true
-          name: Authorization
-          in: header
-          description: '_Service Account_ token, in `Bearer: <token>` format.'
-      responses:
-        '200':
-          schema:
-            $ref: '#/definitions/GeofencingNotifications'
-          description: Success
-        '401':
-          schema:
-            $ref: '#/definitions/UnauthorizedErrors'
-          description: Invalid _ServiceAccountToken_ is used.
-        '403':
-          schema:
-            $ref: '#/definitions/FleetFrobidenErrors'
-          description: Application doesn't have fleet access.
-        '422':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Decoding errors
-        '500':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Server errors
+  /v1/fleets/geofencing/zones:
     post:
       security:
         - ServiceAccountToken: []
       tags:
-        - Geofences
+        - Geofencing
+      summary: Create a zone
+      description: >-
+        **Create** a zone for geofencing based on [GeoJSON](https://geojson.org)
+        (and optional human-readable name).<br> In order for geofencing to work,
+        the _geojson_ needs to represent an _area_ (lines etc. will not produce
+        an effect).<br> <br> A created zone is a _prerequisite_ to connecting
+        vehicles with "geofencing behaviours" (aka _notifications_).
+      operationId: Fleets.Geofencing.Zones.create
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+        - in: body
+          required: true
+          name: body
+          schema:
+            $ref: '#/definitions/GeofencingZoneCreate'
+      responses:
+        '201':
+          schema:
+            $ref: '#/definitions/GeofencingZoneCreated'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+    get:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofencing
+      summary: Get all zones' data
+      description: '**Get** the data for _all_ zones created.'
+      operationId: Fleets.Geofencing.Zones.index
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingZones'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+  /v1/fleets/geofencing/zones/{id}:
+    get:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofencing
+      summary: Get a single zone's data
+      description: >-
+        **Get** the data for a specific zone with the given _ID_.<br> The zone
+        must be created before.
+      operationId: Fleets.Geofencing.Zones.get
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+        - type: string
+          required: true
+          name: id
+          in: path
+          description: _ID_ of the zone to be **fetched**.
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingZone'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '404':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          description: Zone not found - invalid _ID_.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+    delete:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofencing
+      summary: Delete a zone
+      description: >-
+        **Delete** the zone with the given _ID_.<br> If successful,
+        notifications and events associated with this zone are also deleted.
+      operationId: Fleets.Geofencing.Zones.delete
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+        - type: string
+          required: true
+          name: id
+          in: path
+          description: _ID_ of the zone to be **deleted**.
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingZoneDeleted'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '404':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          description: Zone not found - invalid _ID_.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+  /v1/fleets/geofencing/notifications:
+    post:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofencing
       summary: Create a notification
       description: >-
         **Create** a notification that "ties" together a _zone_ and a _vehicle_
@@ -675,17 +671,98 @@ paths:
           schema:
             $ref: '#/definitions/Errors'
           description: Server errors
-  /v1/fleets/geofences/zones/{id}:
+    get:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofencing
+      summary: Get all notifications' data
+      description: '**Get** the data for _all_ notifications created.'
+      operationId: Fleets.Geofencing.Notifications.index
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingNotifications'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
+  /v1/fleets/geofencing/notifications/{id}:
+    get:
+      security:
+        - ServiceAccountToken: []
+      tags:
+        - Geofencing
+      summary: Get a single notification's data
+      description: >-
+        **Get** the data for a specific notification with the given _ID_.<br>
+        The notification must be created before.
+      operationId: Fleets.Geofencing.Notifications.get
+      parameters:
+        - type: string
+          required: true
+          name: Authorization
+          in: header
+          description: '_Service Account_ token, in `Bearer: <token>` format.'
+        - type: string
+          required: true
+          name: id
+          in: path
+          description: _ID_ of the notification to be **fetched**.
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/GeofencingNotification'
+          description: Success
+        '401':
+          schema:
+            $ref: '#/definitions/UnauthorizedErrors'
+          description: Invalid _ServiceAccountToken_ is used.
+        '403':
+          schema:
+            $ref: '#/definitions/FleetFrobidenErrors'
+          description: Application doesn't have fleet access.
+        '404':
+          schema:
+            $ref: '#/definitions/FleetErrors'
+          description: Notification not found - invalid _ID_.
+        '422':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Decoding errors
+        '500':
+          schema:
+            $ref: '#/definitions/Errors'
+          description: Server errors
     delete:
       security:
         - ServiceAccountToken: []
       tags:
-        - Geofences
-      summary: Delete a zone
+        - Geofencing
+      summary: Delete a notification
       description: >-
-        **Delete** the zone with the given _ID_.<br> If successful,
-        notifications and events associated with this zone are also deleted.
-      operationId: Fleets.Geofencing.Zones.delete
+        **Delete** the notification with the given _ID_.<br> If successful,
+        events associated with this notification are also deleted.
+      operationId: Fleets.Geofencing.Notifications.delete
       parameters:
         - type: string
           required: true
@@ -696,11 +773,11 @@ paths:
           required: true
           name: id
           in: path
-          description: _ID_ of the zone to be **deleted**.
+          description: _ID_ of the notification to be **deleted**.
       responses:
         '200':
           schema:
-            $ref: '#/definitions/GeofencingZoneDeleted'
+            $ref: '#/definitions/GeofencingNotificationDeleted'
           description: Success
         '401':
           schema:
@@ -713,7 +790,7 @@ paths:
         '404':
           schema:
             $ref: '#/definitions/FleetErrors'
-          description: Zone not found - invalid _ID_.
+          description: Notification not found - invalid _ID_.
         '422':
           schema:
             $ref: '#/definitions/Errors'
@@ -722,16 +799,20 @@ paths:
           schema:
             $ref: '#/definitions/Errors'
           description: Server errors
+  /v1/fleets/geofencing/events/{vin}:
     get:
       security:
         - ServiceAccountToken: []
       tags:
-        - Geofences
-      summary: Get a single zone's data
+        - Geofencing
+      summary: Get the latest events for a vehicle
       description: >-
-        **Get** the data for a specific zone with the given _ID_.<br> The zone
-        must be created before.
-      operationId: Fleets.Geofencing.Zones.get
+        **Get** the last (up to 5) events of a vehicle with the given _VIN_.<br>
+        The events symbolize the vehicle crossing over boundaries of previously
+        configured geofences and "activating" their triggers.<br> <br> Requires
+        a previously created zone and a notification, and the vehicle to have
+        moved in way to trigger the events.
+      operationId: Fleets.Geofencing.Events.index
       parameters:
         - type: string
           required: true
@@ -740,13 +821,13 @@ paths:
           description: '_Service Account_ token, in `Bearer: <token>` format.'
         - type: string
           required: true
-          name: id
+          name: vin
           in: path
-          description: _ID_ of the zone to be **fetched**.
+          description: _VIN_ of the vehicle to **fetch** the _events_ for.
       responses:
         '200':
           schema:
-            $ref: '#/definitions/GeofencingZone'
+            $ref: '#/definitions/GeofencingEvents'
           description: Success
         '401':
           schema:
@@ -759,88 +840,7 @@ paths:
         '404':
           schema:
             $ref: '#/definitions/FleetErrors'
-          description: Zone not found - invalid _ID_.
-        '422':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Decoding errors
-        '500':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Server errors
-  /v1/fleets/geofences/zones:
-    get:
-      security:
-        - ServiceAccountToken: []
-      tags:
-        - Geofences
-      summary: Get all zones' data
-      description: '**Get** the data for _all_ zones created.'
-      operationId: Fleets.Geofencing.Zones.index
-      parameters:
-        - type: string
-          required: true
-          name: Authorization
-          in: header
-          description: '_Service Account_ token, in `Bearer: <token>` format.'
-      responses:
-        '200':
-          schema:
-            $ref: '#/definitions/GeofencingZones'
-          description: Success
-        '401':
-          schema:
-            $ref: '#/definitions/UnauthorizedErrors'
-          description: Invalid _ServiceAccountToken_ is used.
-        '403':
-          schema:
-            $ref: '#/definitions/FleetFrobidenErrors'
-          description: Application doesn't have fleet access.
-        '422':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Decoding errors
-        '500':
-          schema:
-            $ref: '#/definitions/Errors'
-          description: Server errors
-    post:
-      security:
-        - ServiceAccountToken: []
-      tags:
-        - Geofences
-      summary: Create a zone
-      description: >-
-        **Create** a zone for geofencing based on [GeoJSON](https://geojson.org)
-        (and optional human-readable name).<br> In order for geofencing to work,
-        the _geojson_ needs to represent an _area_ (lines etc. will not produce
-        an effect).<br> <br> A created zone is a _prerequisite_ to connecting
-        vehicles with "geofencing behaviours" (aka _notifications_).
-      operationId: Fleets.Geofencing.Zones.create
-      parameters:
-        - type: string
-          required: true
-          name: Authorization
-          in: header
-          description: '_Service Account_ token, in `Bearer: <token>` format.'
-        - in: body
-          required: true
-          name: body
-          schema:
-            $ref: '#/definitions/GeofencingZoneCreate'
-      responses:
-        '201':
-          schema:
-            $ref: '#/definitions/GeofencingZoneCreated'
-          description: Success
-        '401':
-          schema:
-            $ref: '#/definitions/UnauthorizedErrors'
-          description: Invalid _ServiceAccountToken_ is used.
-        '403':
-          schema:
-            $ref: '#/definitions/FleetFrobidenErrors'
-          description: Application doesn't have fleet access.
+          description: Events not found (or empty) - invalid _VIN_.
         '422':
           schema:
             $ref: '#/definitions/Errors'


### PR DESCRIPTION
This PR adds the _geofencing_ APIs to the Service Account API spec.

In addition, it has a fix (or two) for to the previous spec based on Swagger's [editor's](https://editor.swagger.io) errors.
Also some bigger strings are converted to a different "format" by the editor's "yaml cleanup" function.