### PR TITLE
Update geofencing's `../events/<vin>` spec with `zone_name`

### DIFF
--- a/hm-service-account-api-rest-v1.yml
+++ b/hm-service-account-api-rest-v1.yml
@@ -871,6 +871,7 @@ definitions:
           - event
           - timestamp
           - zone_id
+          - zone_name
         properties:
           event:
             $ref: '#/definitions/GeofencingTrigger'
@@ -882,6 +883,9 @@ definitions:
           zone_id:
             type: string
             description: _ID_ of the zone (geojson) this event happened for.
+          zone_name:
+            type: string
+            description: Name of the zone (geojson) this event happened for.
       vin:
         type: string
         description: _VIN_ of the vehicle in question.
@@ -890,9 +894,11 @@ definitions:
         - event: entered
           timestamp: '2022-02-28T14:01:29Z'
           zone_id: f5bb0c1f-1b22-434a-93c3-489b07b565f8
+          zone_name: berlin_large
         - event: exited
           timestamp: '2022-02-28T15:22:64Z'
           zone_id: f5bb0c1f-1b22-434a-93c3-489b07b565f8
+          zone_name: berlin_large
       vin: VIN11223344556677
   GeofencingNotification:
     type: object


### PR DESCRIPTION
This updates the (geofencing section of) spec with `zone_name` in the `GET ../events/<vin>` endpoint response.