### PR TITLE
Include error status on clearance creation

### DIFF
--- a/hm-fleet-clearance-v1.yml
+++ b/hm-fleet-clearance-v1.yml
@@ -390,6 +390,10 @@ components:
                 unit: kilometers
           - vin: WBADT43452G296404
             brand: bmw
+          - vin: VIN012345678901234
+            brand: ds
+          - vin: VIN01234567890123
+            brand: unknown
       required:
         - vehicles
 
@@ -457,6 +461,9 @@ components:
           - vin: VIN012345678901234
             status: error
             description: vin should be 17 character(s)
+          - vin: VIN0123456789012
+            status: error
+            description: The brand is invalid
 
 
     FleetVin:

--- a/hm-fleet-clearance-v1.yml
+++ b/hm-fleet-clearance-v1.yml
@@ -454,6 +454,9 @@ components:
             status: pending
           - vin: WBADT43452G296404
             status: pending
+          - vin: VIN012345678901234
+            status: error
+            description: vin should be 17 character(s)
 
 
     FleetVin:
@@ -476,6 +479,7 @@ components:
             - revoking
             - canceling
             - canceled
+            - error
           description: >-
             An access token can be retrieved for the FleetVin if the status is
             "approved"


### PR DESCRIPTION
included error as status and example to show errors when given VIN is longer than 17 char