### PR TITLE
Update the spec to match oauth2 spec

### DIFF
--- a/hm-service-account-token-v1.yml
+++ b/hm-service-account-token-v1.yml
@@ -1,8 +1,9 @@
 openapi: 3.0.3
 info:
-  title: Service Account Token API
+  title: OAuth2 For Server-to-Server 
   description: |-
-    The Service Account Token API is where you can get auth tokens to be used for any of the following endpoints:
+    OAuth2 For Server-to-Server (a.k.a Service Account Token API) is an API based on [JSON Web Token (JWT) Profile
+      for OAuth 2.0 Client Authentication and Authorization Grants](https://datatracker.ietf.org/doc/html/rfc7523) specification where you can get access_token tokens to be used for any of the following endpoints:
 
       * [Fleet Clearance API](/api-references/code-references/fleet/clearance/reference/v1/)
       * [Fleet Geofencing API](/api-references/code-references/fleet/geofencing/reference/v1/)
@@ -27,7 +28,7 @@ paths:
   /v1/auth_tokens:
     post:
       tags:
-        - ServiceAccountToken
+        - OAuth JWT Token
       requestBody:
         content:
           application/json:
@@ -57,20 +58,15 @@ paths:
           description: Server Errors
       operationId: ApiWeb.ServiceAccountTokenController.create
       description: >-
-        Creates an authorization token to be used with any of the Service
-        Account API endpoints.
+        Creates an access token to be used in server-to-server comminucations
   
   
   /v1/auth_tokens/{auth_token}:
     delete:
+      deprecated: true
       tags:
-        - ServiceAccountToken    
+        - Deprecated    
       summary: ''
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ServiceAccountTokenRequest'      
       parameters:
         - schema:
             type: string
@@ -122,9 +118,14 @@ components:
           description: >-
             A JWT Signed with the service account key, read more at
             https://high-mobility.com/learn/documentation/cloud-api/service-account-api/intro/
+        grant_type:
+          type: string
+          enum: [urn:ietf:params:oauth:grant-type:jwt-bearer]
+          
       example:
         assertion: >-
           eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJ2ZXIiOjEsImp0aSI6IjA3M2UxOTM1LTkwZDAtNDE0Mi05MTgzLWE4ZTAxNzNhZDJlNyIsImlzcyI6IjAxMDA4MmNjLTYzZTAtNGRmMy05ZmRhLTAzZThkOWQzN2I1OCIsImlhdCI6IjIwMTYtMTAtMDZUMTc6MDQ6MzQuNDQzNDc5KzAwOjAwIiwiYXVkIjoiaHR0cHM6Ly9hcGkuaGlnaC1tb2JpbGl0eS5jb20vYXBpL3YxIn0.MEQCIG8VHMVGJL_rAaxWEvWMoSMmxNBn9Fl46zcEP9l4fFGNAiBDr9bCzx0MLi0pDBMTg1w9ZAl6VJuxeVIC7c6o8YfxQw
+        grant_type: urn:ietf:params:oauth:grant-type:jwt-bearer
           
     UnauthorizedErrors:
       type: object
@@ -149,6 +150,7 @@ components:
         - valid_from
         - auth_token
       properties:
+        access_token: 
         valid_until:
           type: string
           description: When the token expires, formatted in ISO8601
@@ -159,10 +161,10 @@ components:
           type: string
           description: The authorization token
       example:
-        valid_until: '2018-10-25T09:26:26.153089+00:00'
-        valid_from: '2018-10-25T08:26:26.174792+00:00'
-        auth_token: 7c106df8-d947-4cb0-b8a1-fc86038f3efb
-      description: Access token enabling the creation and manipulation of Device Certificates
+        token_type: bearer
+        expires_in: 300
+        access_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODgzNzkwMzksImlhdCI6MTY4ODM3ODczOSwiaXNzIjoiaHR0cHM6Ly9zYW5kYm94LmFwaS5oaWdoLW1vYmlsaXR5LmNvbS92MS9hdXRoX3Rva2VucyIsImp0aSI6IjFiY2ZjOTBkLTQ2NTMtNDQyZS05MmE3LWM5N2U2MmMxMDlmYyIsInNlcnZpY2VfYWNjb3VudF9pZCI6IjYxOTZmZTZlLWE0ZTQtNDZjYi1iM2U3LTZiODk5MmFlOGFjOCIsInN1YiI6IjUxYTNmYmQ5LWEwZjUtNDY1Yi1iOTA3LTM5MWQ1YTBmNjM3NiIsInZlciI6MX0.sXYHak_aKTsqMC5ILgfu-PCgWsACbrdHDKjHRFNTm0M
+        scope: "fleet:clearance fleet:geofencing vehicle:eligibility-check vehicle:data"
 
     Errors:
       type: array


### PR DESCRIPTION
This is the backward compatibility change. The old response will be still available it's just won't be documented.