### PR TITLE
control_measures no longer is needed during clearance creation

### DIFF
--- a/hm-fleet-clearance-v1.yml
+++ b/hm-fleet-clearance-v1.yml
@@ -489,10 +489,6 @@ components:
           - vin: WBADT43452G296403
             brand: mercedes-benz
             tags: {}
-            control_measures:
-              odometer:
-                value: 55271000
-                unit: kilometers
           - vin: WBADT43452G296404
             brand: bmw
             tags: {}
@@ -543,6 +539,7 @@ components:
             - sandbox
           description: Vehicle Brand
         control_measures:
+          deprecated: true
           type: object
           properties:
             odometer:


### PR DESCRIPTION
mark control_measures as deprecated.

it will be shown visually like:
<img width="583" alt="Screenshot 2024-02-09 at 09 44 40" src="https://github.com/highmobility/open-api-specifications/assets/585764/18dfbbbe-59ff-43c0-bf83-62e85ef820c9">
