### PR TITLE
fix issue with overwriting properties

### DIFF
--- a/hm-vehicle-data-api-v1.yml
+++ b/hm-vehicle-data-api-v1.yml
@@ -1,63 +1,5 @@
 components:
   schemas:
-    property_engine_oil_pressure_level:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - low
-            - normal
-            - high
-            - low_soft
-            - low_hard
-            - no_sensor
-            - system_fault
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_low_voltage_battery_charge_level:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - ok
-            - deactivation_level_1
-            - deactivation_level_2
-            - deactivation_level_3
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_impact_zone:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - pedestrian_protection
-            - rollover
-            - rear_passenger_side
-            - rear_driver_side
-            - side_passenger_side
-            - side_driver_side
-            - front_passenger_side
-            - front_driver_side
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     unit_temperature:
       additionalProperties: false
       properties:
@@ -73,12 +15,20 @@ components:
         - unit
         - value
       type: object
-    property_zone:
+    race_property_gear_mode:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_zone'
+          enum:
+            - manual
+            - park
+            - reverse
+            - neutral
+            - drive
+            - low_gear
+            - sport
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -102,31 +52,32 @@ components:
         - location
         - fastened_state
       type: object
-    property_window_open_percentage:
+    usage_property_energy:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_window_open_percentage'
+          $ref: '#/components/schemas/unit_energy'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_hybrid_operating_mode:
+    charging_property_battery_status:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - auto_charge_deplete
-            - auto_charge_sustain
-            - forced_charge_sustain
-            - forced_electric
-            - forced_non_electric
-            - temporary_charge_sustain
-            - prioritize_charge_generation
+            - inactive
+            - active
+            - balancing
+            - external_load
+            - load
+            - error
+            - initialising
+            - conditioning
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -134,12 +85,82 @@ components:
           format: date-time
           type: string
       type: object
-    property_lock:
+    maintenance_property_uinteger:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_lock'
+          maximum: 255
+          minimum: 0
+          type: integer
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    usage_property_timestamp:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          format: date-time
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    doors_property_door_position:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_door_position'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    windscreen_property_wipers_intensity:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - level_0
+            - level_1
+            - level_2
+            - level_3
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    hood_property_lock_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_lock_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_session_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -195,18 +216,6 @@ components:
         - available
         - event
       type: object
-    property_energy:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/unit_energy'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     custom_type_percentage:
       description: Percentage value between 0.0 - 1.0 (0% - 100%)
       type: number
@@ -231,20 +240,20 @@ components:
     hood:
       properties:
         lock:
-          $ref: '#/components/schemas/property_lock_state'
+          $ref: '#/components/schemas/hood_property_lock_state'
           description: Includes the lock state of the hood.
         lock_safety:
-          $ref: '#/components/schemas/property_lock_safety'
+          $ref: '#/components/schemas/hood_property_lock_safety'
           description: Indicates the safe-state of the hood.
         position:
-          $ref: '#/components/schemas/property_position'
+          $ref: '#/components/schemas/hood_property_position'
           description: Position
-    property_angle:
+    chassis_settings_property_spring_rate:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/unit_angle'
+          $ref: '#/components/schemas/custom_type_spring_rate'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -254,245 +263,267 @@ components:
     charging:
       properties:
         distance_to_complete_charge:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/charging_property_length'
           description: Distance until charging completed
         restriction:
-          $ref: '#/components/schemas/property_charging_restriction'
+          $ref: '#/components/schemas/charging_property_charging_restriction'
           description: Charging limit and state
         acoustic_limit:
-          $ref: '#/components/schemas/property_acoustic_limit'
+          $ref: '#/components/schemas/charging_property_acoustic_limit'
           description: Acoustic limitation of charging process.
         battery_level_at_departure:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/charging_property_percentage'
           description: Battery charge level expected at time of departure
         charging_phases:
-          $ref: '#/components/schemas/property_charging_phases'
+          $ref: '#/components/schemas/charging_property_charging_phases'
           description: Charging process count of the high-voltage battery (phases).
         battery_voltage:
-          $ref: '#/components/schemas/property_electric_potential_difference'
+          $ref: '#/components/schemas/charging_property_electric_potential_difference'
           description: High-voltage battery electric potential difference (aka voltage).
         status:
-          $ref: '#/components/schemas/property_status'
+          $ref: '#/components/schemas/charging_property_status'
           description: Status
         charge_port_state:
-          $ref: '#/components/schemas/property_position'
+          $ref: '#/components/schemas/charging_property_position'
           description: Charge port state
         charging_time_display:
-          $ref: '#/components/schemas/property_charging_time_display'
+          $ref: '#/components/schemas/charging_property_charging_time_display'
           description: Charging time displayed in the vehicle.
         charging_current:
-          $ref: '#/components/schemas/property_electric_current'
+          $ref: '#/components/schemas/charging_property_electric_current'
           description: Charging electric current.
         charging_single_immediate:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/charging_property_active_state'
           description: Single instant charging function status.
         fully_charged_end_times:
-          $ref: '#/components/schemas/property_weekday_time'
+          $ref: '#/components/schemas/charging_property_weekday_time'
           description: Time and weekday when the vehicle will be fully charged.
         max_charging_current:
-          $ref: '#/components/schemas/property_electric_current'
+          $ref: '#/components/schemas/charging_property_electric_current'
           description: Maximum charging current
         current_limit:
-          $ref: '#/components/schemas/property_electric_current'
+          $ref: '#/components/schemas/charging_property_electric_current'
           description: Limit for the charging current.
         hybrid_operating_mode:
-          $ref: '#/components/schemas/property_hybrid_operating_mode'
+          $ref: '#/components/schemas/charging_property_hybrid_operating_mode'
           description: Operating mode of the hybrid vehicle.
         station_status:
-          $ref: '#/components/schemas/property_station_status'
+          $ref: '#/components/schemas/charging_property_station_status'
           description: Status of the charging station.
         charging_window_chosen:
-          $ref: '#/components/schemas/property_charging_window_chosen'
+          $ref: '#/components/schemas/charging_property_charging_window_chosen'
           description: Charging window chosen
         preconditioning_immediate_status:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/charging_property_active_state'
           description: Status of immediate preconditioning
         preconditioning_remaining_time:
-          $ref: '#/components/schemas/property_duration'
+          $ref: '#/components/schemas/charging_property_duration'
           description: Time until preconditioning is complete.
         limit_status:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/charging_property_active_state'
           description: Indicates whether charging limit is active.
         flap_lock_status:
-          $ref: '#/components/schemas/property_lock_state'
+          $ref: '#/components/schemas/charging_property_lock_state'
           description: Locking status of charging flap.
         departure_times:
           description: Departure times
           items:
-            $ref: '#/components/schemas/property_departure_time'
+            $ref: '#/components/schemas/charging_property_departure_time'
           type: array
         departure_time_display:
-          $ref: '#/components/schemas/property_departure_time_display'
+          $ref: '#/components/schemas/charging_property_departure_time_display'
           description: Departure time displayed in the vehicle.
         battery_max_available:
-          $ref: '#/components/schemas/property_energy'
+          $ref: '#/components/schemas/charging_property_energy'
           description: Maximum available energy content of the high-voltage battery.
         smart_charging_status:
-          $ref: '#/components/schemas/property_smart_charging_status'
+          $ref: '#/components/schemas/charging_property_smart_charging_status'
           description: Status of optimized/intelligent charging
         charger_voltage:
-          $ref: '#/components/schemas/property_electric_potential_difference'
+          $ref: '#/components/schemas/charging_property_electric_potential_difference'
           description: Charger voltage
         battery_current_dc:
-          $ref: '#/components/schemas/property_electric_current'
+          $ref: '#/components/schemas/charging_property_electric_current'
           deprecated: true
           description: Battery direct current
         preconditioning_departure_status:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/charging_property_active_state'
           description: Status of preconditioning at departure time
         current_type:
-          $ref: '#/components/schemas/property_current_type'
+          $ref: '#/components/schemas/charging_property_current_type'
           description: Type of current in use
         battery_charge_transfer_event:
-          $ref: '#/components/schemas/property_battery_charge_transfer_event'
+          $ref: '#/components/schemas/charging_property_battery_charge_transfer_event'
           description: Indicates that the high-voltage battery lost state of charge due to an energy transfer to the 12V battery.
         station_power_type:
-          $ref: '#/components/schemas/property_station_power_type'
+          $ref: '#/components/schemas/charging_property_station_power_type'
           description: The power type of the connected charging station.
         charger_voltage_dc:
-          $ref: '#/components/schemas/property_electric_potential_difference'
+          $ref: '#/components/schemas/charging_property_electric_potential_difference'
           deprecated: true
           description: Charger voltage for direct current
         battery_temperature_extremes:
-          $ref: '#/components/schemas/property_temperature_extreme'
+          $ref: '#/components/schemas/charging_property_temperature_extreme'
           description: Current highest-lowest temperature inside the battery.
         starter_battery_state:
-          $ref: '#/components/schemas/property_starter_battery_state'
+          $ref: '#/components/schemas/charging_property_starter_battery_state'
           description: State of the starter battery
         charging_end_reason:
-          $ref: '#/components/schemas/property_charging_end_reason'
+          $ref: '#/components/schemas/charging_property_charging_end_reason'
           description: Reason for ending a charging process.
         charge_limit:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/charging_property_percentage'
           description: Charge limit percentage between 0.0-1.0
         min_charging_current:
-          $ref: '#/components/schemas/property_electric_current'
+          $ref: '#/components/schemas/charging_property_electric_current'
           description: Minimum charging current.
         battery_tempretature_extremes:
-          $ref: '#/components/schemas/property_temperature_extreme'
+          $ref: '#/components/schemas/charging_property_temperature_extreme'
           deprecated: true
           description: Current highest-lowest temperature inside the battery.
         max_range:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/charging_property_length'
           description: Maximum electric range with 100% of battery
         battery_capacity:
-          $ref: '#/components/schemas/property_energy'
+          $ref: '#/components/schemas/charging_property_energy'
           description: Indicates the battery capacity
         reduction_times:
           description: Reduction of charging times
           items:
-            $ref: '#/components/schemas/property_reduction_time'
+            $ref: '#/components/schemas/charging_property_reduction_time'
           type: array
         battery_temperature_control_demand:
-          $ref: '#/components/schemas/property_battery_temperature_control_demand'
+          $ref: '#/components/schemas/charging_property_battery_temperature_control_demand'
           description: Current demand of HV battery temperature control system.
         battery_level:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/charging_property_percentage'
           description: Battery level percentage between 0.0-1.0
         plug_type:
-          $ref: '#/components/schemas/property_plug_type'
+          $ref: '#/components/schemas/charging_property_plug_type'
           description: Plug type
         battery_current:
-          $ref: '#/components/schemas/property_electric_current'
+          $ref: '#/components/schemas/charging_property_electric_current'
           description: Battery current - charging if posititive and discharning when negative.
         charger_voltage_ac:
-          $ref: '#/components/schemas/property_electric_potential_difference'
+          $ref: '#/components/schemas/charging_property_electric_potential_difference'
           deprecated: true
           description: Charger voltage for alternating current
         battery_led:
-          $ref: '#/components/schemas/property_battery_led'
+          $ref: '#/components/schemas/charging_property_battery_led'
           description: State of LED for the battery.
         time_to_complete_charge:
-          $ref: '#/components/schemas/property_duration'
+          $ref: '#/components/schemas/charging_property_duration'
           description: Time until charging completed
         plugged_in:
-          $ref: '#/components/schemas/property_plugged_in'
+          $ref: '#/components/schemas/charging_property_plugged_in'
           description: Plugged in
         preconditioning_error:
-          $ref: '#/components/schemas/property_preconditioning_error'
+          $ref: '#/components/schemas/charging_property_preconditioning_error'
           description: Preconditioning error if one is encountered
         timers:
           description: Timers
           items:
-            $ref: '#/components/schemas/property_timer'
+            $ref: '#/components/schemas/charging_property_timer'
           type: array
         driving_mode_phev:
-          $ref: '#/components/schemas/property_driving_mode_phev'
+          $ref: '#/components/schemas/charging_property_driving_mode_phev'
           description: Indicates the current driving mode for Plug-In Hybrid Vehicle.
         battery_status:
-          $ref: '#/components/schemas/property_battery_status'
+          $ref: '#/components/schemas/charging_property_battery_status'
           description: Battery state.
         battery_temperature:
-          $ref: '#/components/schemas/property_temperature'
+          $ref: '#/components/schemas/charging_property_temperature'
           description: Battery temperature
         battery_cooling_temperature:
-          $ref: '#/components/schemas/property_temperature'
+          $ref: '#/components/schemas/charging_property_temperature'
           description: Battery cooling temperature.
         battery_performance_status:
-          $ref: '#/components/schemas/property_battery_performance_status'
+          $ref: '#/components/schemas/charging_property_battery_performance_status'
           description: Performance status of the xEV battery.
         estimated_range:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/charging_property_length'
           description: Estimated range
         plug_lock_status:
-          $ref: '#/components/schemas/property_lock_state'
+          $ref: '#/components/schemas/charging_property_lock_state'
           description: Locking status of charging plug.
         estimated_range_target:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/charging_property_length'
           description: Remaining electric range depending on target charging status.
         preconditioning_departure_enabled:
-          $ref: '#/components/schemas/property_enabled_state'
+          $ref: '#/components/schemas/charging_property_enabled_state'
           description: Preconditioning activation status at departure
         charge_mode:
-          $ref: '#/components/schemas/property_charge_mode'
+          $ref: '#/components/schemas/charging_property_charge_mode'
           description: Charge mode
         battery_energy:
-          $ref: '#/components/schemas/property_energy'
+          $ref: '#/components/schemas/charging_property_energy'
           description: Energy content of the high-voltage battery.
         charging_rate:
-          $ref: '#/components/schemas/property_power'
+          $ref: '#/components/schemas/charging_property_power'
           description: Charge rate when charging
         battery_current_ac:
-          $ref: '#/components/schemas/property_electric_current'
+          $ref: '#/components/schemas/charging_property_electric_current'
           deprecated: true
           description: Battery alternating current
         charging_rate_kw:
-          $ref: '#/components/schemas/property_power'
+          $ref: '#/components/schemas/charging_property_power'
           deprecated: true
           description: Charging rate
         station_displayed_status:
-          $ref: '#/components/schemas/property_station_displayed_status'
+          $ref: '#/components/schemas/charging_property_station_displayed_status'
           description: Status shown on the display of the charging station.
         auxiliary_power:
-          $ref: '#/components/schemas/property_power'
+          $ref: '#/components/schemas/charging_property_power'
           description: Auxiliary power used for predictions.
         charging_complete_lock:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/charging_property_active_state'
           description: Locking status of the charging plug after charging complete.
         battery_energy_chargable:
-          $ref: '#/components/schemas/property_energy'
+          $ref: '#/components/schemas/charging_property_energy'
           description: Energy required until high-voltage battery is fully charged.
         charger_power:
-          $ref: '#/components/schemas/property_power'
+          $ref: '#/components/schemas/charging_property_power'
           description: Power of the charger.
         smart_charging_option:
-          $ref: '#/components/schemas/property_smart_charging_option'
+          $ref: '#/components/schemas/charging_property_smart_charging_option'
           description: Smart charging option being used to charge with.
         battery_charge_type:
-          $ref: '#/components/schemas/property_battery_charge_type'
+          $ref: '#/components/schemas/charging_property_battery_charge_type'
           description: Battery charge type.
         preconditioning_scheduled_time:
-          $ref: '#/components/schemas/property_time'
+          $ref: '#/components/schemas/charging_property_time'
           description: Preconditioning scheduled departure time.
-    property_plugged_in:
+    notifications_property_uinteger:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - disconnected
-            - plugged_in
-            - plugged_in_both_sides
+          maximum: 255
+          minimum: 0
+          type: integer
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    usage_property_acceleration_duration:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_acceleration_duration'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    messaging_property_string:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -522,6 +553,24 @@ components:
         - price
         - currency
       type: object
+    power_takeoff_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_network_security:
       description: Network security
       enum:
@@ -530,18 +579,6 @@ components:
         - wpa
         - wpa2_personal
       type: string
-    property_door_position:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_door_position'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     unit_frequency:
       additionalProperties: false
       properties:
@@ -581,6 +618,18 @@ components:
         - unit
         - value
       type: object
+    windows_property_window_open_percentage:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_window_open_percentage'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_detected:
       description: Detected
       enum:
@@ -609,6 +658,20 @@ components:
         - text
         - status
       type: object
+    diagnostics_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     response500:
       properties:
         errors:
@@ -626,48 +689,15 @@ components:
           description: The request tracking id. Provide request_id when facing issue
           example: e4828bf1-8687-4f7b-b8c7-6c4223e2b842
           type: string
-    property_windscreen_damage:
+    charging_property_smart_charging_status:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - no_impact_detected
-            - impact_but_no_damage_detected
-            - damage_smaller_than_1_inch
-            - damage_larger_than_1_inch
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_tipped_state:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - tipped_over
-            - not_tipped
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_wipers_intensity:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - level_0
-            - level_1
-            - level_2
-            - level_3
+            - wallbox_is_active
+            - scc_is_active
+            - peak_setting_active
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -689,12 +719,18 @@ components:
         - location
         - lock_state
       type: object
-    property_weekday_time:
+    weather_conditions_property_nonce:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_weekday_time'
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -721,83 +757,7 @@ components:
         - axle
         - spring_rate
       type: object
-    property_uinteger:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          maximum: 255
-          minimum: 0
-          type: integer
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_timer:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_timer'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_accelerator_duration:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_accelerator_duration'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_integer:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          maximum: 127
-          minimum: -128
-          type: integer
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_park_assist:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_park_assist'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    dashboard_lights:
-      properties:
-        bulb_failures:
-          description: Vehicle light bulb failure
-          items:
-            $ref: '#/components/schemas/property_bulb_failures'
-          type: array
-        dashboard_lights:
-          description: Dashboard lights
-          items:
-            $ref: '#/components/schemas/property_dashboard_light'
-          type: array
-    property_percentage:
+    vehicle_location_property_percentage:
       additionalProperties: false
       minProperties: 1
       properties:
@@ -809,17 +769,43 @@ components:
           format: date-time
           type: string
       type: object
-    property_switch_position:
+    fueling_property_position:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_position'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    dashboard_lights_property_bulb_failures:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - automatic
-            - dipped_headlights
-            - parking_light_right
-            - parking_light_left
-            - sidelights
+            - turn_signal_left
+            - turn_signal_right
+            - low_beam
+            - low_beam_left
+            - low_beam_right
+            - high_beam
+            - high_beam_left
+            - high_beam_right
+            - fog_light_front
+            - fog_light_rear
+            - stop
+            - position
+            - day_running
+            - trailer_turn
+            - trailer_turn_left
+            - trailer_turn_right
+            - trailer_stop
+            - trailer_electrical_failure
+            - multiple
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -827,12 +813,53 @@ components:
           format: date-time
           type: string
       type: object
-    property_pressure:
+    race_property_angular_velocity:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/unit_pressure'
+          $ref: '#/components/schemas/unit_angular_velocity'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    dashboard_lights:
+      properties:
+        bulb_failures:
+          description: Vehicle light bulb failure
+          items:
+            $ref: '#/components/schemas/dashboard_lights_property_bulb_failures'
+          type: array
+        dashboard_lights:
+          description: Dashboard lights
+          items:
+            $ref: '#/components/schemas/dashboard_lights_property_dashboard_light'
+          type: array
+    charging_property_enabled_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_enabled_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_battery_performance_status:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - normal
+            - caution
+            - reduced
+            - severly_reduced
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -856,47 +883,65 @@ components:
         - location
         - state
       type: object
-    property_power:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/unit_power'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     custom_type_muted:
       description: Muted
       enum:
         - not_muted
         - muted
       type: string
+    usage_property_trip_meter:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_trip_meter'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     vehicle_location:
       properties:
         altitude:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/vehicle_location_property_length'
           description: Altitude above the WGS 84 reference ellipsoid
         coordinates:
-          $ref: '#/components/schemas/property_coordinates'
+          $ref: '#/components/schemas/vehicle_location_property_coordinates'
           description: Coordinates
         fuzzy_coordinates:
-          $ref: '#/components/schemas/property_coordinates'
+          $ref: '#/components/schemas/vehicle_location_property_coordinates'
           description: Fuzzy coordinates for the vehicle location.
         gps_signal_strength:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/vehicle_location_property_percentage'
           description: GPS signal strength percentage between 0.0-1.0
         gps_source:
-          $ref: '#/components/schemas/property_gps_source'
+          $ref: '#/components/schemas/vehicle_location_property_gps_source'
           description: Type of GPS source
         heading:
-          $ref: '#/components/schemas/property_angle'
+          $ref: '#/components/schemas/vehicle_location_property_angle'
           description: Heading angle
         precision:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/vehicle_location_property_length'
           description: Precision
+    honk_horn_flash_lights_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_rgb_colour:
       additionalProperties: false
       description: RGB colour
@@ -915,24 +960,47 @@ components:
         - green
         - blue
       type: object
-    property_distance_over_time:
+    charging_property_current_type:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_distance_over_time'
+          enum:
+            - alternating_current
+            - direct_current
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_driving_mode:
+    charging_property_station_status:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_driving_mode'
+          enum:
+            - not_compatible
+            - not_detected
+            - digital_communication_established
+            - digital_communication_ended
+            - station_ready
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    parking_brake_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -964,48 +1032,52 @@ components:
         - type
         - duration
       type: object
-    property_duration:
+    usage_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/unit_duration'
+          maxLength: 17
+          minLength: 17
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_enabled_state:
+    climate_property_weekday_time:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_enabled_state'
+          $ref: '#/components/schemas/custom_type_weekday_time'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_brake_service_status:
+    dashboard_lights_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_brake_service_status'
+          maxLength: 17
+          minLength: 17
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_reading_lamp:
+    charging_session_property_percentage:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_reading_lamp'
+          $ref: '#/components/schemas/custom_type_percentage'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -1026,15 +1098,46 @@ components:
         - axle
         - state
       type: object
-    property_battery_charge_transfer_event:
+    charging_property_acoustic_limit:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - low_voltage_battery_service_required
-            - low_voltage_battery_high_usage
-            - vehicle_service_required
+            - no_action
+            - automatic
+            - unlimited
+            - limited
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    theft_alarm_property_timestamp:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          format: date-time
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    rooftop_control_property_sunroof_rain_event:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - no_event
+            - in_stroke_position_because_of_rain
+            - automatically_in_stroke_position
+            - timer
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -1087,12 +1190,93 @@ components:
         - type
         - value
       type: object
-    property_dashboard_light:
+    windscreen_property_wipers_status:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_dashboard_light'
+          enum:
+            - inactive
+            - active
+            - automatic
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_timer:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_timer'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    race_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    race_property_vehicle_moving:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - not_moving
+            - moving
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    engine_property_active_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_active_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    remote_control_property_angle:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_angle'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    diagnostics_property_duration:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_duration'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -1105,30 +1289,12 @@ components:
         - disabled
         - enabled
       type: string
-    property_seatbelt_state:
+    charging_property_time:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_seatbelt_state'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_preconditioning_error:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - no_change
-            - not_possible_low
-            - not_possible_finished
-            - available_after_engine_restart
-            - general_error
-          type: string
+          $ref: '#/components/schemas/custom_type_time'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -1261,39 +1427,30 @@ components:
         doors:
           $ref: '#/components/schemas/doors'
       type: object
-    property_departure_time:
+    ignition_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_departure_time'
+          maxLength: 17
+          minLength: 17
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_service_status:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_service_status'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_smart_charging_status:
+    charging_property_station_power_type:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - wallbox_is_active
-            - scc_is_active
-            - peak_setting_active
+            - ac_basic
+            - ac_smart
+            - dc_fast
+            - wireless
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -1336,36 +1493,67 @@ components:
         - location
         - position
       type: object
-    property_time:
+    charging_session_property_string:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_time'
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_battery_led:
+    lights_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    race_property_acceleration:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_acceleration'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_status:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - no_colour
-            - white
-            - yellow
-            - green
-            - red
-            - yellow_pulsing
-            - green_pulsing
-            - red_pulsing
-            - green_red_pulsing
-            - green_flashing
+            - not_charging
+            - charging
+            - charging_complete
             - initialising
-            - error
+            - charging_paused
+            - charging_error
+            - cable_unplugged
+            - slow_charging
+            - fast_charging
+            - discharging
+            - foreign_object_detected
+            - conditioning
+            - flap_open
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -1373,15 +1561,15 @@ components:
           format: date-time
           type: string
       type: object
-    property_last_event_level:
+    vehicle_location_property_gps_source:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - low
-            - medium
-            - high
+            - dead_reckoning
+            - real
+            - none
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -1389,14 +1577,48 @@ components:
           format: date-time
           type: string
       type: object
-    property_engaged:
+    usage_property_percentage:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - not_engaged
-            - engaged
+          $ref: '#/components/schemas/custom_type_percentage'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    race_property_percentage:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_percentage'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    rooftop_control_property_percentage:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_percentage'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_session_property_timestamp:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          format: date-time
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -1407,35 +1629,12 @@ components:
     fueling:
       properties:
         gas_flap_lock:
-          $ref: '#/components/schemas/property_lock_state'
+          $ref: '#/components/schemas/fueling_property_lock_state'
           description: Gas flap lock
         gas_flap_position:
-          $ref: '#/components/schemas/property_position'
+          $ref: '#/components/schemas/fueling_property_position'
           description: Gas flap position
-    property_charging_end_reason:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - unknown
-            - goal_reached
-            - requested_by_driver
-            - connector_removed
-            - powergrid_failed
-            - hv_system_failure
-            - charging_station_failure
-            - parking_lock_failed
-            - no_parking_lock
-            - signal_invalid
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_nonce:
+    trunk_property_nonce:
       additionalProperties: false
       minProperties: 1
       properties:
@@ -1458,12 +1657,12 @@ components:
         open_percentages:
           description: Open percentages
           items:
-            $ref: '#/components/schemas/property_window_open_percentage'
+            $ref: '#/components/schemas/windows_property_window_open_percentage'
           type: array
         positions:
           description: Positions
           items:
-            $ref: '#/components/schemas/property_window_position'
+            $ref: '#/components/schemas/windows_property_window_position'
           type: array
     custom_type_tire_pressure_status:
       additionalProperties: false
@@ -1485,29 +1684,34 @@ components:
         - location
         - status
       type: object
-    property_timestamp:
+    parking_brake_property_active_state:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          format: date-time
-          type: string
+          $ref: '#/components/schemas/custom_type_active_state'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_charging_phases:
+    theft_alarm_property_event_type:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - no_charging
-            - one
-            - two
-            - three
+            - idle
+            - front_left
+            - front_middle
+            - front_right
+            - right
+            - rear_right
+            - rear_middle
+            - rear_left
+            - left
+            - unknown
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -1515,12 +1719,43 @@ components:
           format: date-time
           type: string
       type: object
-    property_driving_mode_activation_period:
+    maintenance_property_brake_service_due_date:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_driving_mode_activation_period'
+          $ref: '#/components/schemas/custom_type_brake_service_due_date'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    race_property_active_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_active_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    remote_control_property_control_mode:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - unavailable
+            - available
+            - started
+            - failed_to_start
+            - aborted
+            - ended
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -1551,58 +1786,60 @@ components:
         - closed
         - open
       type: string
-    property_charging_location:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_charging_location'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     windscreen:
       properties:
         windscreen_damage:
-          $ref: '#/components/schemas/property_windscreen_damage'
+          $ref: '#/components/schemas/windscreen_property_windscreen_damage'
           description: Windscreen damage
         windscreen_damage_confidence:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/windscreen_property_percentage'
           description: Confidence of damage detection, 0% if no impact detected
         windscreen_damage_detection_time:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/windscreen_property_timestamp'
           description: Windscreen damage detection date
         windscreen_damage_zone:
-          $ref: '#/components/schemas/property_zone'
+          $ref: '#/components/schemas/windscreen_property_zone'
           description: Representing the position in the zone, seen from the inside of the vehicle (1-based index)
         windscreen_needs_replacement:
-          $ref: '#/components/schemas/property_windscreen_needs_replacement'
+          $ref: '#/components/schemas/windscreen_property_windscreen_needs_replacement'
           description: Windscreen needs replacement
         windscreen_zone_matrix:
-          $ref: '#/components/schemas/property_zone'
+          $ref: '#/components/schemas/windscreen_property_zone'
           description: Representing the size of the matrix, seen from the inside of the vehicle
         wipers_intensity:
-          $ref: '#/components/schemas/property_wipers_intensity'
+          $ref: '#/components/schemas/windscreen_property_wipers_intensity'
           description: Wipers intensity
         wipers_status:
-          $ref: '#/components/schemas/property_wipers_status'
+          $ref: '#/components/schemas/windscreen_property_wipers_status'
           description: Wipers status
-    property_battery_temperature_control_demand:
+    theft_alarm_property_last_warning_reason:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - high_cooling
-            - medium_cooling
-            - low_cooling
-            - no_temperature_requirement
-            - low_heating
-            - medium_heating
-            - high_heating
-            - circulation_requirement
+            - no_alarm
+            - basic_alarm
+            - door_front_left
+            - door_front_right
+            - door_rear_left
+            - door_rear_right
+            - hood
+            - trunk
+            - common_alm_in
+            - panic
+            - glovebox
+            - center_box
+            - rear_box
+            - sensor_vta
+            - its
+            - its_slv
+            - tps
+            - horn
+            - hold_com
+            - remote
+            - unknown
+            - siren
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -1610,12 +1847,24 @@ components:
           format: date-time
           type: string
       type: object
-    property_rgb_colour:
+    seats_property_seatbelt_state:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_rgb_colour'
+          $ref: '#/components/schemas/custom_type_seatbelt_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    usage_property_energy_efficiency:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_energy_efficiency'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -1632,6 +1881,24 @@ components:
         - high
         - very_high
       type: string
+    adas_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_dashboard_light:
       additionalProperties: false
       description: Dashboard light
@@ -1864,6 +2131,24 @@ components:
         - unit
         - value
       type: object
+    charging_property_preconditioning_error:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - no_change
+            - not_possible_low
+            - not_possible_finished
+            - available_after_engine_restart
+            - general_error
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_driving_mode:
       description: Driving mode
       enum:
@@ -1874,17 +2159,82 @@ components:
         - eco_plus
         - comfort
       type: string
+    diagnostics_property_oem_trouble_code_value:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_oem_trouble_code_value'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    adas_property_blind_spot_warning_system_coverage:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - regular
+            - trailer
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     trunk:
       properties:
         lock:
-          $ref: '#/components/schemas/property_lock_state'
+          $ref: '#/components/schemas/trunk_property_lock_state'
           description: Lock
         lock_safety:
-          $ref: '#/components/schemas/property_lock_safety'
+          $ref: '#/components/schemas/trunk_property_lock_safety'
           description: Indicates the safe-state of the trunk.
         position:
-          $ref: '#/components/schemas/property_position'
+          $ref: '#/components/schemas/trunk_property_position'
           description: Position
+    lights_property_light:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_light'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    notifications_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_session_property_duration:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_duration'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     response504:
       properties:
         errors:
@@ -1902,16 +2252,42 @@ components:
           description: The request tracking id. Provide request_id when facing issue
           example: e4828bf1-8687-4f7b-b8c7-6c4223e2b842
           type: string
-    property_status:
+    crash_property_enabled_state:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - normal
-            - restraints_engaged
-            - airbag_triggered
+          $ref: '#/components/schemas/custom_type_enabled_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
           type: string
+      type: object
+    usage_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    engine_property_duration:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_duration'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -1950,6 +2326,48 @@ components:
         - unit
         - value
       type: object
+    trunk_property_lock_safety:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_lock_safety'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    remote_control_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    usage_property_driving_mode_activation_period:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_driving_mode_activation_period'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_supported_capability:
       additionalProperties: false
       description: Supported capability
@@ -1965,6 +2383,68 @@ components:
       required:
         - capability_id
         - supported_property_ids
+      type: object
+    honk_horn_flash_lights_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    dashboard_lights_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    usage_property_speed:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_speed'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    ignition_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
       type: object
     custom_type_charging_point:
       additionalProperties: false
@@ -1988,42 +2468,31 @@ components:
         - street
         - provider
       type: object
-    property_fuel_efficiency:
+    hood_property_nonce:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/unit_fuel_efficiency'
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_type:
+    messaging_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - pedestrian
-            - non_pedestrian
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_sunroof_tilt_state:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - closed
-            - tilted
-            - half_tilted
+          maxLength: 17
+          minLength: 17
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -2031,19 +2500,50 @@ components:
           format: date-time
           type: string
       type: object
-    property_control_mode:
+    remote_control_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - unavailable
-            - available
-            - started
-            - failed_to_start
-            - aborted
-            - ended
+          maxLength: 17
+          minLength: 17
           type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    lights_property_active_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_active_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    chassis_settings_property_length:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_length'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_temperature_extreme:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_temperature_extreme'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2056,26 +2556,29 @@ components:
         - unlocked
         - locked
       type: string
-    property_clear:
+    diagnostics_property_service_status:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - clear
-          type: string
+          $ref: '#/components/schemas/custom_type_service_status'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_charging_point:
+    maintenance_property_teleservice_availability:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_charging_point'
+          enum:
+            - pending
+            - idle
+            - successful
+            - error
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2088,199 +2591,347 @@ components:
         - 'off'
         - 'on'
       type: string
-    diagnostics:
-      properties:
-        brake_lining_wear_pre_warning:
-          $ref: '#/components/schemas/property_active_state'
-          description: Status of brake lining wear pre-warning
-        distance_since_reset:
-          $ref: '#/components/schemas/property_length'
-          description: The distance driven since reset
-        estimated_secondary_powertrain_range:
-          $ref: '#/components/schemas/property_length'
-          description: Estimated secondary powertrain range
-        engine_coolant_fluid_level:
-          $ref: '#/components/schemas/property_fluid_level'
-          description: Engine coolant fluid level
-        anti_lock_braking:
-          $ref: '#/components/schemas/property_active_state'
-          description: Anti-lock braking system (ABS)
-        mileage:
-          $ref: '#/components/schemas/property_length'
-          deprecated: true
-          description: The vehicle mileage (odometer)
-        battery_voltage:
-          $ref: '#/components/schemas/property_electric_potential_difference'
-          description: Battery voltage
-        distance_since_start:
-          $ref: '#/components/schemas/property_length'
-          description: The distance driven since trip start
-        fuel_level:
-          $ref: '#/components/schemas/property_percentage'
-          description: Fuel level percentage between 0.0-1.0
-        passenger_airbag_status:
-          $ref: '#/components/schemas/property_active_state'
-          description: Passenger airbag is activated or not
-        check_control_messages:
-          description: Check control messages
-          items:
-            $ref: '#/components/schemas/property_check_control_message'
-          type: array
-        washer_fluid_level:
-          $ref: '#/components/schemas/property_fluid_level'
-          description: Washer fluid level
-        tire_pressure_statuses:
-          description: Tire pressure statuses
-          items:
-            $ref: '#/components/schemas/property_tire_pressure_status'
-          type: array
-        engine_rpm:
-          $ref: '#/components/schemas/property_angular_velocity'
-          description: Engine RPM (revolutions per minute)
-        fuel_volume:
-          $ref: '#/components/schemas/property_volume'
-          description: The fuel volume measured in liters
-        diesel_particulate_filter_soot_level:
-          $ref: '#/components/schemas/property_percentage'
-          description: Level of soot in diesel exhaust particulate filter
-        oem_trouble_code_values:
-          description: Additional OEM trouble codes
-          items:
-            $ref: '#/components/schemas/property_oem_trouble_code_value'
-          type: array
-        adblue_level:
-          $ref: '#/components/schemas/property_percentage'
-          description: AdBlue level percentage between 0.0-1.0
-        backup_battery_remaining_time:
-          $ref: '#/components/schemas/property_duration'
-          description: Remaining time the backup battery can work.
-        odometer:
-          $ref: '#/components/schemas/property_length'
-          description: The vehicle odometer value in a given units
-        tire_pressures:
-          description: Tire pressures
-          items:
-            $ref: '#/components/schemas/property_tire_pressure'
-          type: array
-        wheel_based_speed:
-          $ref: '#/components/schemas/property_speed'
-          description: The vehicle speed measured at the wheel base
-        engine_oil_pressure_level:
-          $ref: '#/components/schemas/property_engine_oil_pressure_level'
-          description: Engine oil pressure level
-        engine_total_fuel_consumption:
-          $ref: '#/components/schemas/property_volume'
-          description: The accumulated lifespan fuel consumption
-        engine_total_operating_time:
-          $ref: '#/components/schemas/property_duration'
-          description: The accumulated time of engine operation
-        engine_total_operating_hours:
-          $ref: '#/components/schemas/property_duration'
-          deprecated: true
-          description: The accumulated time of engine operation
-        engine_coolant_temperature:
-          $ref: '#/components/schemas/property_temperature'
-          description: Engine coolant temperature
-        battery_level:
-          $ref: '#/components/schemas/property_percentage'
-          description: Battery level in %, value between 0.0 and 1.0
-        engine_time_to_next_service:
-          $ref: '#/components/schemas/property_duration'
-          description: Engine time until next service of the vehicle
-        mileage_meters:
-          $ref: '#/components/schemas/property_length'
-          deprecated: true
-          description: The vehicle mileage (odometer) in meters
-        engine_load:
-          $ref: '#/components/schemas/property_percentage'
-          description: Current engine load percentage between 0.0-1.0
-        engine_oil_amount:
-          $ref: '#/components/schemas/property_volume'
-          description: The current estimated oil tank liquid fill.
-        trouble_codes:
-          description: Trouble codes
-          items:
-            $ref: '#/components/schemas/property_trouble_code'
-          type: array
-        engine_torque:
-          $ref: '#/components/schemas/property_percentage'
-          description: Current engine torque percentage between 0.0-1.0
-        diesel_exhaust_fluid_range:
-          $ref: '#/components/schemas/property_length'
-          description: Distance remaining until diesel exhaust fluid is empty
-        estimated_range:
-          $ref: '#/components/schemas/property_length'
-          description: Estimated range (with combustion engine)
-        wheel_rpms:
-          description: Wheel RPMs
-          items:
-            $ref: '#/components/schemas/property_wheel_rpm'
-          type: array
-        engine_oil_life_remaining:
-          $ref: '#/components/schemas/property_percentage'
-          description: Remaining life of engine oil which decreases over time
-        confirmed_trouble_codes:
-          description: Confirmed trouble codes
-          items:
-            $ref: '#/components/schemas/property_confirmed_trouble_code'
-          type: array
-        brake_fluid_level:
-          $ref: '#/components/schemas/property_fluid_level'
-          description: Brake fluid level
-        engine_total_idle_operating_time:
-          $ref: '#/components/schemas/property_duration'
-          description: The accumulated time of engine operation
-        tire_pressures_targets:
-          description: Target tire pressures for the vehicle.
-          items:
-            $ref: '#/components/schemas/property_tire_pressure'
-          type: array
-        low_voltage_battery_charge_level:
-          $ref: '#/components/schemas/property_low_voltage_battery_charge_level'
-          description: Indicates if the charge level of the low voltage battery is too low to use other systems
-        tire_pressures_differences:
-          description: Tire pressures difference from the target pressure.
-          items:
-            $ref: '#/components/schemas/property_tire_pressure'
-          type: array
-        engine_oil_level:
-          $ref: '#/components/schemas/property_percentage'
-          description: The current estimated oil tank liquid fill in percentage.
-        fuel_level_accuracy:
-          $ref: '#/components/schemas/property_fuel_level_accuracy'
-          description: This value includes the information, if the fuel level has been calculated or measured.
-        tire_temperatures:
-          description: Tire temperatures
-          items:
-            $ref: '#/components/schemas/property_tire_temperature'
-          type: array
-        speed:
-          $ref: '#/components/schemas/property_speed'
-          description: The vehicle speed
-        engine_oil_fluid_level:
-          $ref: '#/components/schemas/property_fluid_level'
-          description: Engine oil fluid level
-        engine_oil_service_status:
-          $ref: '#/components/schemas/property_service_status'
-          description: Engine oil service status
-        diesel_exhaust_filter_status:
-          description: Diesel exhaust filter status
-          items:
-            $ref: '#/components/schemas/property_diesel_exhaust_filter_status'
-          type: array
-        engine_oil_temperature:
-          $ref: '#/components/schemas/property_temperature'
-          description: Engine oil temperature
-    property_station_power_type:
+    charging_property_charging_phases:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - ac_basic
-            - ac_smart
-            - dc_fast
-            - wireless
+            - no_charging
+            - one
+            - two
+            - three
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    diagnostics_property_speed:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_speed'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    hood_property_lock_safety:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_lock_safety'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    diagnostics:
+      properties:
+        brake_lining_wear_pre_warning:
+          $ref: '#/components/schemas/diagnostics_property_active_state'
+          description: Status of brake lining wear pre-warning
+        distance_since_reset:
+          $ref: '#/components/schemas/diagnostics_property_length'
+          description: The distance driven since reset
+        estimated_secondary_powertrain_range:
+          $ref: '#/components/schemas/diagnostics_property_length'
+          description: Estimated secondary powertrain range
+        engine_coolant_fluid_level:
+          $ref: '#/components/schemas/diagnostics_property_fluid_level'
+          description: Engine coolant fluid level
+        anti_lock_braking:
+          $ref: '#/components/schemas/diagnostics_property_active_state'
+          description: Anti-lock braking system (ABS)
+        mileage:
+          $ref: '#/components/schemas/diagnostics_property_length'
+          deprecated: true
+          description: The vehicle mileage (odometer)
+        battery_voltage:
+          $ref: '#/components/schemas/diagnostics_property_electric_potential_difference'
+          description: Battery voltage
+        distance_since_start:
+          $ref: '#/components/schemas/diagnostics_property_length'
+          description: The distance driven since trip start
+        fuel_level:
+          $ref: '#/components/schemas/diagnostics_property_percentage'
+          description: Fuel level percentage between 0.0-1.0
+        passenger_airbag_status:
+          $ref: '#/components/schemas/diagnostics_property_active_state'
+          description: Passenger airbag is activated or not
+        check_control_messages:
+          description: Check control messages
+          items:
+            $ref: '#/components/schemas/diagnostics_property_check_control_message'
+          type: array
+        washer_fluid_level:
+          $ref: '#/components/schemas/diagnostics_property_fluid_level'
+          description: Washer fluid level
+        tire_pressure_statuses:
+          description: Tire pressure statuses
+          items:
+            $ref: '#/components/schemas/diagnostics_property_tire_pressure_status'
+          type: array
+        engine_rpm:
+          $ref: '#/components/schemas/diagnostics_property_angular_velocity'
+          description: Engine RPM (revolutions per minute)
+        fuel_volume:
+          $ref: '#/components/schemas/diagnostics_property_volume'
+          description: The fuel volume measured in liters
+        diesel_particulate_filter_soot_level:
+          $ref: '#/components/schemas/diagnostics_property_percentage'
+          description: Level of soot in diesel exhaust particulate filter
+        oem_trouble_code_values:
+          description: Additional OEM trouble codes
+          items:
+            $ref: '#/components/schemas/diagnostics_property_oem_trouble_code_value'
+          type: array
+        adblue_level:
+          $ref: '#/components/schemas/diagnostics_property_percentage'
+          description: AdBlue level percentage between 0.0-1.0
+        backup_battery_remaining_time:
+          $ref: '#/components/schemas/diagnostics_property_duration'
+          description: Remaining time the backup battery can work.
+        odometer:
+          $ref: '#/components/schemas/diagnostics_property_length'
+          description: The vehicle odometer value in a given units
+        tire_pressures:
+          description: Tire pressures
+          items:
+            $ref: '#/components/schemas/diagnostics_property_tire_pressure'
+          type: array
+        wheel_based_speed:
+          $ref: '#/components/schemas/diagnostics_property_speed'
+          description: The vehicle speed measured at the wheel base
+        engine_oil_pressure_level:
+          $ref: '#/components/schemas/diagnostics_property_engine_oil_pressure_level'
+          description: Engine oil pressure level
+        engine_total_fuel_consumption:
+          $ref: '#/components/schemas/diagnostics_property_volume'
+          description: The accumulated lifespan fuel consumption
+        engine_total_operating_time:
+          $ref: '#/components/schemas/diagnostics_property_duration'
+          description: The accumulated time of engine operation
+        engine_total_operating_hours:
+          $ref: '#/components/schemas/diagnostics_property_duration'
+          deprecated: true
+          description: The accumulated time of engine operation
+        engine_coolant_temperature:
+          $ref: '#/components/schemas/diagnostics_property_temperature'
+          description: Engine coolant temperature
+        battery_level:
+          $ref: '#/components/schemas/diagnostics_property_percentage'
+          description: Battery level in %, value between 0.0 and 1.0
+        engine_time_to_next_service:
+          $ref: '#/components/schemas/diagnostics_property_duration'
+          description: Engine time until next service of the vehicle
+        mileage_meters:
+          $ref: '#/components/schemas/diagnostics_property_length'
+          deprecated: true
+          description: The vehicle mileage (odometer) in meters
+        engine_load:
+          $ref: '#/components/schemas/diagnostics_property_percentage'
+          description: Current engine load percentage between 0.0-1.0
+        engine_oil_amount:
+          $ref: '#/components/schemas/diagnostics_property_volume'
+          description: The current estimated oil tank liquid fill.
+        trouble_codes:
+          description: Trouble codes
+          items:
+            $ref: '#/components/schemas/diagnostics_property_trouble_code'
+          type: array
+        engine_torque:
+          $ref: '#/components/schemas/diagnostics_property_percentage'
+          description: Current engine torque percentage between 0.0-1.0
+        diesel_exhaust_fluid_range:
+          $ref: '#/components/schemas/diagnostics_property_length'
+          description: Distance remaining until diesel exhaust fluid is empty
+        estimated_range:
+          $ref: '#/components/schemas/diagnostics_property_length'
+          description: Estimated range (with combustion engine)
+        wheel_rpms:
+          description: Wheel RPMs
+          items:
+            $ref: '#/components/schemas/diagnostics_property_wheel_rpm'
+          type: array
+        engine_oil_life_remaining:
+          $ref: '#/components/schemas/diagnostics_property_percentage'
+          description: Remaining life of engine oil which decreases over time
+        confirmed_trouble_codes:
+          description: Confirmed trouble codes
+          items:
+            $ref: '#/components/schemas/diagnostics_property_confirmed_trouble_code'
+          type: array
+        brake_fluid_level:
+          $ref: '#/components/schemas/diagnostics_property_fluid_level'
+          description: Brake fluid level
+        engine_total_idle_operating_time:
+          $ref: '#/components/schemas/diagnostics_property_duration'
+          description: The accumulated time of engine operation
+        tire_pressures_targets:
+          description: Target tire pressures for the vehicle.
+          items:
+            $ref: '#/components/schemas/diagnostics_property_tire_pressure'
+          type: array
+        low_voltage_battery_charge_level:
+          $ref: '#/components/schemas/diagnostics_property_low_voltage_battery_charge_level'
+          description: Indicates if the charge level of the low voltage battery is too low to use other systems
+        tire_pressures_differences:
+          description: Tire pressures difference from the target pressure.
+          items:
+            $ref: '#/components/schemas/diagnostics_property_tire_pressure'
+          type: array
+        engine_oil_level:
+          $ref: '#/components/schemas/diagnostics_property_percentage'
+          description: The current estimated oil tank liquid fill in percentage.
+        fuel_level_accuracy:
+          $ref: '#/components/schemas/diagnostics_property_fuel_level_accuracy'
+          description: This value includes the information, if the fuel level has been calculated or measured.
+        tire_temperatures:
+          description: Tire temperatures
+          items:
+            $ref: '#/components/schemas/diagnostics_property_tire_temperature'
+          type: array
+        speed:
+          $ref: '#/components/schemas/diagnostics_property_speed'
+          description: The vehicle speed
+        engine_oil_fluid_level:
+          $ref: '#/components/schemas/diagnostics_property_fluid_level'
+          description: Engine oil fluid level
+        engine_oil_service_status:
+          $ref: '#/components/schemas/diagnostics_property_service_status'
+          description: Engine oil service status
+        diesel_exhaust_filter_status:
+          description: Diesel exhaust filter status
+          items:
+            $ref: '#/components/schemas/diagnostics_property_diesel_exhaust_filter_status'
+          type: array
+        engine_oil_temperature:
+          $ref: '#/components/schemas/diagnostics_property_temperature'
+          description: Engine oil temperature
+    charging_property_electric_potential_difference:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_electric_potential_difference'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    crash_property_tipped_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - tipped_over
+            - not_tipped
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    rooftop_control_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    adas_property_park_assist:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_park_assist'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    lights_property_rgb_colour:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_rgb_colour'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    climate_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    doors_property_lock_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_lock_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    race_property_integer:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maximum: 127
+          minimum: -128
+          type: integer
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_charging_window_chosen:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - not_chosen
+            - chosen
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -2291,17 +2942,35 @@ components:
     power_takeoff:
       properties:
         engaged:
-          $ref: '#/components/schemas/property_engaged'
+          $ref: '#/components/schemas/power_takeoff_property_engaged'
           description: Engaged
         status:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/power_takeoff_property_active_state'
           description: Status
-    property_brake_service_remaining_distance:
+    fueling_property_nonce:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_brake_service_remaining_distance'
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    diagnostics_property_wheel_rpm:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_wheel_rpm'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2314,16 +2983,59 @@ components:
         - front
         - rear
       type: string
-    property_smart_charging_option:
+    windscreen_property_timestamp:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          format: date-time
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    windscreen_property_windscreen_needs_replacement:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - price_optimized
-            - renewable_energy
-            - co2_optimized
+            - unknown
+            - no_replacement_needed
+            - replacement_needed
           type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_charge_mode:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - immediate
+            - timer_based
+            - inductive
+            - conductive
+            - push_button
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_energy:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_energy'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2333,26 +3045,24 @@ components:
     ignition:
       properties:
         accessories_status:
-          $ref: '#/components/schemas/property_ignition_state'
+          $ref: '#/components/schemas/ignition_property_ignition_state'
           deprecated: true
           description: Accessories status
         state:
-          $ref: '#/components/schemas/property_ignition_state'
+          $ref: '#/components/schemas/ignition_property_ignition_state'
           description: State
         status:
-          $ref: '#/components/schemas/property_ignition_state'
+          $ref: '#/components/schemas/ignition_property_ignition_state'
           deprecated: true
           description: Status
-    property_position:
+    crash_property_uinteger:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - closed
-            - open
-            - intermediate
-          type: string
+          maximum: 255
+          minimum: 0
+          type: integer
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2390,28 +3100,6 @@ components:
         - ecu_variant_name
         - status
       type: object
-    property_drivetrain_state:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - inactive
-            - race_start_preparation
-            - race_start
-            - start
-            - comfort_start
-            - start_idle_run_control
-            - ready_for_overpressing
-            - low_speed_mode
-            - e_launch
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     unit_mass:
       additionalProperties: false
       properties:
@@ -2440,12 +3128,128 @@ components:
         - unit
         - value
       type: object
-    property_coordinates:
+    fueling_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_coordinates'
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    climate_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    diagnostics_property_length:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_length'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    doors_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_reduction_time:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_reduction_time'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    crash_property_status:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - normal
+            - restraints_engaged
+            - airbag_triggered
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    engine_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    weather_conditions_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    lights_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2486,18 +3290,6 @@ components:
         - location
         - rpm
       type: object
-    property_oem_trouble_code_value:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_oem_trouble_code_value'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     custom_type_driving_mode_energy_consumption:
       additionalProperties: false
       description: Driving mode energy consumption
@@ -2512,18 +3304,6 @@ components:
         - driving_mode
         - consumption
       type: object
-    property_lock_safety:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_lock_safety'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     custom_type_brake_service_remaining_distance:
       additionalProperties: false
       description: Brake service remaining distance
@@ -2537,6 +3317,30 @@ components:
       required:
         - axle
         - distance
+      type: object
+    diagnostics_property_check_control_message:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_check_control_message'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    fueling_property_lock_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_lock_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
       type: object
     custom_type_acceleration:
       additionalProperties: false
@@ -2574,12 +3378,12 @@ components:
           description: The request tracking id. Provide request_id when facing issue
           example: a8306c7c-9f57-453c-8189-d06118944770
           type: string
-    property_temperature_extreme:
+    diagnostics_property_percentage:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_temperature_extreme'
+          $ref: '#/components/schemas/custom_type_percentage'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2591,16 +3395,16 @@ components:
         action_items:
           description: Action items
           items:
-            $ref: '#/components/schemas/property_action_item'
+            $ref: '#/components/schemas/notifications_property_action_item'
           type: array
         activated_action:
-          $ref: '#/components/schemas/property_uinteger'
+          $ref: '#/components/schemas/notifications_property_uinteger'
           description: Identifier of the activated action
         clear:
-          $ref: '#/components/schemas/property_clear'
+          $ref: '#/components/schemas/notifications_property_clear'
           description: Clear
         text:
-          $ref: '#/components/schemas/property_string'
+          $ref: '#/components/schemas/notifications_property_string'
           description: Text for the notification
     custom_type_triggered:
       description: Triggered
@@ -2622,6 +3426,32 @@ components:
         - location
         - open_percentage
       type: object
+    power_takeoff_property_active_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_active_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    light_conditions_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_reduction_time:
       additionalProperties: false
       description: Reduction time
@@ -2637,6 +3467,18 @@ components:
         - start_stop
         - time
       type: object
+    maintenance_property_brake_service_status:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_brake_service_status'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_action_item:
       additionalProperties: false
       description: Action item
@@ -2650,6 +3492,51 @@ components:
       required:
         - id
         - name
+      type: object
+    crash_property_crash_incident:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_crash_incident'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    honk_horn_flash_lights_property_flashers:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - inactive
+            - emergency_flasher_active
+            - left_flasher_active
+            - right_flasher_active
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    rooftop_control_property_sunroof_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - closed
+            - open
+            - intermediate
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
       type: object
     unit_speed:
       additionalProperties: false
@@ -2667,12 +3554,36 @@ components:
         - unit
         - value
       type: object
-    property_charging_restriction:
+    notifications_property_nonce:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_charging_restriction'
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    engine_property_preconditioning_status:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - standby
+            - heating
+            - cooling
+            - ventilation
+            - inactive
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2686,15 +3597,12 @@ components:
         - normal
         - warning
       type: string
-    property_wipers_status:
+    maintenance_property_timestamp:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - inactive
-            - active
-            - automatic
+          format: date-time
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -2721,24 +3629,6 @@ components:
         - driver_number
         - working_state
       type: object
-    property_preconditioning_status:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - standby
-            - heating
-            - cooling
-            - ventilation
-            - inactive
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     custom_type_key_value:
       additionalProperties: false
       description: Key-value pairs like in a dictionary or hash
@@ -2753,44 +3643,92 @@ components:
         - key
         - value
       type: object
-    theft_alarm:
+    charging_session_property_charging_point:
+      additionalProperties: false
+      minProperties: 1
       properties:
-        event_type:
-          $ref: '#/components/schemas/property_event_type'
-          description: Position of the last even relative to the vehicle
-        interior_protection_status:
-          $ref: '#/components/schemas/property_active_selected_state'
-          description: Interior protection sensor status
-        interior_protection_triggered:
-          $ref: '#/components/schemas/property_triggered'
-          description: Indicates whether the interior protection sensors are triggered.
-        last_event:
-          $ref: '#/components/schemas/property_timestamp'
-          description: Last event happening date
-        last_event_level:
-          $ref: '#/components/schemas/property_last_event_level'
-          description: Level of impact for the last event
-        last_warning_reason:
-          $ref: '#/components/schemas/property_last_warning_reason'
-          description: Last warning reason
-        status:
-          $ref: '#/components/schemas/property_status'
-          description: Status
-        tow_protection_status:
-          $ref: '#/components/schemas/property_active_selected_state'
-          description: Tow protection sensor status
-        tow_protection_triggered:
-          $ref: '#/components/schemas/property_triggered'
-          description: Indicates whether the tow protection sensors are triggered.
-    property_gps_source:
+        data:
+          $ref: '#/components/schemas/custom_type_charging_point'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_battery_charge_type:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - dead_reckoning
-            - real
-            - none
+            - no_charge
+            - normal
+            - accelerated
+            - fast
+            - quick
+            - ultra_fast
+            - not_used
+            - vehicle_to_home
+            - vehicle_to_grid
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    theft_alarm:
+      properties:
+        event_type:
+          $ref: '#/components/schemas/theft_alarm_property_event_type'
+          description: Position of the last even relative to the vehicle
+        interior_protection_status:
+          $ref: '#/components/schemas/theft_alarm_property_active_selected_state'
+          description: Interior protection sensor status
+        interior_protection_triggered:
+          $ref: '#/components/schemas/theft_alarm_property_triggered'
+          description: Indicates whether the interior protection sensors are triggered.
+        last_event:
+          $ref: '#/components/schemas/theft_alarm_property_timestamp'
+          description: Last event happening date
+        last_event_level:
+          $ref: '#/components/schemas/theft_alarm_property_last_event_level'
+          description: Level of impact for the last event
+        last_warning_reason:
+          $ref: '#/components/schemas/theft_alarm_property_last_warning_reason'
+          description: Last warning reason
+        status:
+          $ref: '#/components/schemas/theft_alarm_property_status'
+          description: Status
+        tow_protection_status:
+          $ref: '#/components/schemas/theft_alarm_property_active_selected_state'
+          description: Tow protection sensor status
+        tow_protection_triggered:
+          $ref: '#/components/schemas/theft_alarm_property_triggered'
+          description: Indicates whether the tow protection sensors are triggered.
+    theft_alarm_property_last_event_level:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - low
+            - medium
+            - high
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    windscreen_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -2801,14 +3739,38 @@ components:
     weather_conditions:
       properties:
         rain_intensity:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/weather_conditions_property_percentage'
           description: Measured raining intensity percentage, whereas 0% is no rain and 100% is maximum rain
-    property_brake_torque_vectoring:
+    charging_session_property_charging_location:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_brake_torque_vectoring'
+          $ref: '#/components/schemas/custom_type_charging_location'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    vehicle_location_property_coordinates:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_coordinates'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    diagnostics_property_confirmed_trouble_code:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_confirmed_trouble_code'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2832,6 +3794,22 @@ components:
           description: The request tracking id. Provide request_id when facing issue
           example: a8306c7c-9f57-453c-8189-d06118944770
           type: string
+    chassis_settings_property_sport_chrono:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - inactive
+            - active
+            - reset
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_weekday:
       description: Weekday
       enum:
@@ -2844,12 +3822,24 @@ components:
         - sunday
         - automatic
       type: string
-    property_string:
+    vehicle_location_property_angle:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
+          $ref: '#/components/schemas/unit_angle'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
           type: string
+      type: object
+    offroad_property_angle:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_angle'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2867,6 +3857,22 @@ components:
         - rear_left_outer
         - spare
       type: string
+    charging_property_departure_time_display:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - no_display
+            - reachable
+            - not_reachable
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_driving_mode_activation_period:
       additionalProperties: false
       description: Driving mode activation period
@@ -2881,12 +3887,30 @@ components:
         - driving_mode
         - period
       type: object
-    property_crash_incident:
+    diagnostics_property_active_state:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_crash_incident'
+          $ref: '#/components/schemas/custom_type_active_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    race_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2912,19 +3936,31 @@ components:
         persons_detected:
           description: Persons detected
           items:
-            $ref: '#/components/schemas/property_person_detected'
+            $ref: '#/components/schemas/seats_property_person_detected'
           type: array
         seatbelts_state:
           description: Seatbelts state
           items:
-            $ref: '#/components/schemas/property_seatbelt_state'
+            $ref: '#/components/schemas/seats_property_seatbelt_state'
           type: array
-    property_confirmed_trouble_code:
+    climate_property_active_state:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_confirmed_trouble_code'
+          $ref: '#/components/schemas/custom_type_active_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    adas_property_lane_keep_assist_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_lane_keep_assist_state'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2939,6 +3975,30 @@ components:
         - rear_right
         - rear_left
       type: string
+    usage_property_driving_mode_energy_consumption:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_driving_mode_energy_consumption'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    adas_property_active_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_active_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     unit_fuel_efficiency:
       additionalProperties: false
       properties:
@@ -2954,24 +4014,38 @@ components:
         - unit
         - value
       type: object
-    property_diesel_exhaust_filter_status:
+    charging_session_property_charging_cost:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_diesel_exhaust_filter_status'
+          $ref: '#/components/schemas/custom_type_charging_cost'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_charging_cost:
+    diagnostics_property_volume:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_charging_cost'
+          $ref: '#/components/schemas/unit_volume'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    notifications_property_clear:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - clear
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -2985,15 +4059,40 @@ components:
         - inactive_not_selected
         - active
       type: string
-    property_charging_window_chosen:
+    windows_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - not_chosen
-            - chosen
+          maxLength: 17
+          minLength: 17
           type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    offroad_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_position:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_position'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -3014,17 +4113,66 @@ components:
         - location
         - state
       type: object
-    property_plug_type:
+    diagnostics_property_nonce:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - type_1
-            - type_2
-            - ccs
-            - chademo
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
           type: string
+      type: object
+    charging_session_property_length:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_length'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    theft_alarm_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    offroad_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -3045,6 +4193,18 @@ components:
         - location
         - detected
       type: object
+    usage_property_volume:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_volume'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_timer:
       additionalProperties: false
       description: Timer
@@ -3064,25 +4224,15 @@ components:
         - timer_type
         - date
       type: object
-    offroad:
-      properties:
-        route_incline:
-          $ref: '#/components/schemas/property_angle'
-          description: The route elevation incline
-        wheel_suspension:
-          $ref: '#/components/schemas/property_percentage'
-          description: The wheel suspension level percentage, whereas 0.0 is no suspension and 1.0 maximum suspension
-    property_starter_battery_state:
+    rooftop_control_property_sunroof_tilt_state:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - red
-            - yellow
-            - green
-            - orange
-            - green_yellow
+            - closed
+            - tilted
+            - half_tilted
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -3090,6 +4240,50 @@ components:
           format: date-time
           type: string
       type: object
+    lights_property_reading_lamp:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_reading_lamp'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    race_property_accelerator_duration:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_accelerator_duration'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    climate_property_power:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_power'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    offroad:
+      properties:
+        route_incline:
+          $ref: '#/components/schemas/offroad_property_angle'
+          description: The route elevation incline
+        wheel_suspension:
+          $ref: '#/components/schemas/offroad_property_percentage'
+          description: The wheel suspension level percentage, whereas 0.0 is no suspension and 1.0 maximum suspension
     unit_torque:
       additionalProperties: false
       properties:
@@ -3105,40 +4299,6 @@ components:
         - unit
         - value
       type: object
-    property_battery_charge_type:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - no_charge
-            - normal
-            - accelerated
-            - fast
-            - quick
-            - ultra_fast
-            - not_used
-            - vehicle_to_home
-            - vehicle_to_grid
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_lock_state:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_lock_state'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     custom_type_service_status:
       description: Service-Status
       enum:
@@ -3146,6 +4306,18 @@ components:
         - warning
         - critical
       type: string
+    diagnostics_property_electric_potential_difference:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_electric_potential_difference'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     unit_angular_velocity:
       additionalProperties: false
       properties:
@@ -3161,27 +4333,16 @@ components:
         - unit
         - value
       type: object
-    property_blind_spot_warning_system_coverage:
+    charging_property_battery_charge_transfer_event:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - regular
-            - trailer
+            - low_voltage_battery_service_required
+            - low_voltage_battery_high_usage
+            - vehicle_service_required
           type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_temperature:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/unit_temperature'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -3193,80 +4354,87 @@ components:
         accelerations:
           description: Accelerations
           items:
-            $ref: '#/components/schemas/property_acceleration'
+            $ref: '#/components/schemas/race_property_acceleration'
           type: array
         accelerator_durations:
           description: Duration during which the accelerator pedal has been pressed more than the given percentage.
           items:
-            $ref: '#/components/schemas/property_accelerator_duration'
+            $ref: '#/components/schemas/race_property_accelerator_duration'
           type: array
         accelerator_pedal_idle_switch:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/race_property_active_state'
           description: Accelerator pedal idle switch
         accelerator_pedal_kickdown_switch:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/race_property_active_state'
           description: Accelerator pedal kickdown switch
         brake_pedal_position:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/race_property_percentage'
           description: The brake pedal position between 0.0-1.0, wheras 1.0 (100%) is full brakes
         brake_pedal_switch:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/race_property_active_state'
           description: Brake pedal switch
         brake_pressure:
-          $ref: '#/components/schemas/property_pressure'
+          $ref: '#/components/schemas/race_property_pressure'
           description: Brake pressure
         brake_torque_vectorings:
           description: Brake torque vectorings
           items:
-            $ref: '#/components/schemas/property_brake_torque_vectoring'
+            $ref: '#/components/schemas/race_property_brake_torque_vectoring'
           type: array
         clutch_pedal_switch:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/race_property_active_state'
           description: Clutch pedal switch
         drivetrain_state:
-          $ref: '#/components/schemas/property_drivetrain_state'
+          $ref: '#/components/schemas/race_property_drivetrain_state'
           description: State of the drivetrain for starts.
         electronic_stability_program:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/race_property_active_state'
           description: Electronic stability program
         gas_pedal_position:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/race_property_percentage'
           description: The gas pedal position between 0.0-1.0, whereas 1.0 (100%) is full throttle
         gear_mode:
-          $ref: '#/components/schemas/property_gear_mode'
+          $ref: '#/components/schemas/race_property_gear_mode'
           description: Gear mode
         oversteering:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/race_property_percentage'
           description: The oversteering percentage between 0.0-1.0 whereas up to 0.2 (20%) is considered OK, up to 30% marginal, over 30% critical
         rear_suspension_steering:
-          $ref: '#/components/schemas/property_angle'
+          $ref: '#/components/schemas/race_property_angle'
           description: Rear suspension steering
         selected_gear:
-          $ref: '#/components/schemas/property_integer'
+          $ref: '#/components/schemas/race_property_integer'
           description: The selected gear value, if any
         steering_angle:
-          $ref: '#/components/schemas/property_angle'
+          $ref: '#/components/schemas/race_property_angle'
           description: The steering angle, whereas 0.0 is straight ahead, positive number to the right and negative number to the left
         understeering:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/race_property_percentage'
           description: The understeering percentage between 0.0-1.0 whereas up to 0.2 (20%) is considered OK, up to 0.3 (30%) marginal, over 30% critical
         vehicle_moving:
-          $ref: '#/components/schemas/property_vehicle_moving'
+          $ref: '#/components/schemas/race_property_vehicle_moving'
           description: Vehicle moving
         yaw_rate:
-          $ref: '#/components/schemas/property_angular_velocity'
+          $ref: '#/components/schemas/race_property_angular_velocity'
           description: Yaw turning rate
-    property_battery_performance_status:
+    maintenance_property_condition_based_service:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - normal
-            - caution
-            - reduced
-            - severly_reduced
+          $ref: '#/components/schemas/custom_type_condition_based_service'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
           type: string
+      type: object
+    charging_property_weekday_time:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_weekday_time'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -3312,12 +4480,66 @@ components:
         - pedal_position_threshold
         - duration
       type: object
-    property_triggered:
+    charging_property_charging_restriction:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_triggered'
+          $ref: '#/components/schemas/custom_type_charging_restriction'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    diagnostics_property_diesel_exhaust_filter_status:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_diesel_exhaust_filter_status'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_length:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_length'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_plugged_in:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - disconnected
+            - plugged_in
+            - plugged_in_both_sides
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    chassis_settings_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -3327,182 +4549,192 @@ components:
     climate:
       properties:
         air_conditioner_compressor_power:
-          $ref: '#/components/schemas/property_power'
+          $ref: '#/components/schemas/climate_property_power'
           description: Electric air conditioner compressor power.
         defogging_state:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/climate_property_active_state'
           description: Defogging state
         defrosting_state:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/climate_property_active_state'
           description: Defrosting state
         defrosting_temperature_setting:
-          $ref: '#/components/schemas/property_temperature'
+          $ref: '#/components/schemas/climate_property_temperature'
           description: The defrosting temperature setting
         driver_temperature_setting:
-          $ref: '#/components/schemas/property_temperature'
+          $ref: '#/components/schemas/climate_property_temperature'
           description: The driver temperature setting
         humidity:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/climate_property_percentage'
           description: Measured relative humidity between 0.0 - 1.0.
         hvac_state:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/climate_property_active_state'
           description: HVAC state
         hvac_weekday_starting_times:
           description: HVAC weekday starting times
           items:
-            $ref: '#/components/schemas/property_weekday_time'
+            $ref: '#/components/schemas/climate_property_weekday_time'
           type: array
         inside_temperature:
-          $ref: '#/components/schemas/property_temperature'
+          $ref: '#/components/schemas/climate_property_temperature'
           description: The inside temperature
         ionising_state:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/climate_property_active_state'
           description: Ionising state
         outside_temperature:
-          $ref: '#/components/schemas/property_temperature'
+          $ref: '#/components/schemas/climate_property_temperature'
           description: The outside temperature
         passenger_temperature_setting:
-          $ref: '#/components/schemas/property_temperature'
+          $ref: '#/components/schemas/climate_property_temperature'
           description: The passenger temperature setting
         rear_temperature_setting:
-          $ref: '#/components/schemas/property_temperature'
+          $ref: '#/components/schemas/climate_property_temperature'
           description: The rear temperature
     maintenance:
       properties:
         drive_in_inspection_status:
-          $ref: '#/components/schemas/property_service_status'
+          $ref: '#/components/schemas/maintenance_property_service_status'
           description: Drive-in inspection service status.
         brakes_service_due_dates:
           description: Brakes servicing due dates.
           items:
-            $ref: '#/components/schemas/property_brake_service_due_date'
+            $ref: '#/components/schemas/maintenance_property_brake_service_due_date'
           type: array
         drive_in_inspection_distance_to:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/maintenance_property_length'
           description: The distance until next drive-in inspection of the vehicle
         months_to_exhaust_inspection:
-          $ref: '#/components/schemas/property_duration'
+          $ref: '#/components/schemas/maintenance_property_duration'
           deprecated: true
           description: Time until exhaust inspection
         teleservice_battery_call_date:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/maintenance_property_timestamp'
           description: Teleservice batter call date
         distance_to_next_oil_service:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/maintenance_property_length'
           description: Indicates the remaining distance until the next oil service; if this limit was exceeded, this value indicates the distance that has been driven since then.
         brake_fluid_remaining_distance:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/maintenance_property_length'
           description: Indicates the remaining distance for brake fluid.
         teleservice_availability:
-          $ref: '#/components/schemas/property_teleservice_availability'
+          $ref: '#/components/schemas/maintenance_property_teleservice_availability'
           description: Teleservice availability
         cbs_reports_count:
-          $ref: '#/components/schemas/property_uinteger'
+          $ref: '#/components/schemas/maintenance_property_uinteger'
           description: The number of CBS reports
         service_time_threshold:
-          $ref: '#/components/schemas/property_duration'
+          $ref: '#/components/schemas/maintenance_property_duration'
           description: Time threshold for service
         brakes_service_statuses:
           description: Brakes servicing statuses.
           items:
-            $ref: '#/components/schemas/property_brake_service_status'
+            $ref: '#/components/schemas/maintenance_property_brake_service_status'
           type: array
         next_inspection_date:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/maintenance_property_timestamp'
           description: Next inspection date
         time_to_next_service:
-          $ref: '#/components/schemas/property_duration'
+          $ref: '#/components/schemas/maintenance_property_duration'
           description: Time until next servicing of the vehicle
         brakes_service_remaining_distances:
           description: Brakes servicing remaining distances.
           items:
-            $ref: '#/components/schemas/property_brake_service_remaining_distance'
+            $ref: '#/components/schemas/maintenance_property_brake_service_remaining_distance'
           type: array
         last_ecall:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/maintenance_property_timestamp'
           description: Date-time of the last eCall
         time_to_exhaust_inspection:
-          $ref: '#/components/schemas/property_duration'
+          $ref: '#/components/schemas/maintenance_property_duration'
           description: Time until exhaust inspection
         time_to_next_oil_service:
-          $ref: '#/components/schemas/property_duration'
+          $ref: '#/components/schemas/maintenance_property_duration'
           description: Indicates the time remaining until the next oil service; if this limit was exceeded, this value indicates the time that has passed since then.
         drive_in_inspection_date:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/maintenance_property_timestamp'
           description: Next drive-in inspection date.
         kilometers_to_next_service:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/maintenance_property_length'
           deprecated: true
           description: The distance until next servicing of the vehicle
         service_date:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/maintenance_property_timestamp'
           description: Date of the earliest service. If this service is overdue, the date is in the past.
         days_to_next_service:
-          $ref: '#/components/schemas/property_duration'
+          $ref: '#/components/schemas/maintenance_property_duration'
           deprecated: true
           description: Time until next servicing of the car
         brake_fluid_status:
-          $ref: '#/components/schemas/property_service_status'
+          $ref: '#/components/schemas/maintenance_property_service_status'
           description: Brake fluid's service status.
         brake_fluid_change_date:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/maintenance_property_timestamp'
           description: Brake fluid change date
         inspection_status:
-          $ref: '#/components/schemas/property_service_status'
+          $ref: '#/components/schemas/maintenance_property_service_status'
           description: Vehicle inspection service status.
         service_distance_threshold:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/maintenance_property_length'
           description: Distance threshold for service
         vehicle_check_date:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/maintenance_property_timestamp'
           description: Vehicle check date (usually after a predetermined distance).
         next_oil_service_date:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/maintenance_property_timestamp'
           description: Next oil service date.
         vehicle_check_distance_to:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/maintenance_property_length'
           description: The distance until next vehicle check.
         condition_based_services:
           description: Condition based services
           items:
-            $ref: '#/components/schemas/property_condition_based_service'
+            $ref: '#/components/schemas/maintenance_property_condition_based_service'
           type: array
         legal_inspection_date:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/maintenance_property_timestamp'
           description: Next legally required inspection date
         automatic_teleservice_call_date:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/maintenance_property_timestamp'
           description: Automatic teleservice call date
         next_inspection_distance_to:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/maintenance_property_length'
           description: Distance until the next inspection.
         vehicle_check_status:
-          $ref: '#/components/schemas/property_service_status'
+          $ref: '#/components/schemas/maintenance_property_service_status'
           description: Vehicle check service status.
         distance_to_next_service:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/maintenance_property_length'
           description: The distance until next servicing of the vehicle
         service_status:
-          $ref: '#/components/schemas/property_service_status'
+          $ref: '#/components/schemas/maintenance_property_service_status'
           description: 'Consolidated status regarding service requirements. OK: no current service requirement, WARNING: at least one service has reported requirement, CRITICAL: at least one service is overdue.'
-    property_acceleration:
+    crash_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_acceleration'
+          maxLength: 17
+          minLength: 17
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_spring_rate:
+    charging_property_hybrid_operating_mode:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_spring_rate'
+          enum:
+            - auto_charge_deplete
+            - auto_charge_sustain
+            - forced_charge_sustain
+            - forced_electric
+            - forced_non_electric
+            - temporary_charge_sustain
+            - prioritize_charge_generation
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -3515,6 +4747,37 @@ components:
         - safe
         - unsafe
       type: string
+    charging_property_plug_type:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - type_1
+            - type_2
+            - ccs
+            - chademo
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    seats_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_window_location:
       description: Window location
       enum:
@@ -3524,24 +4787,53 @@ components:
         - rear_left
         - hatch
       type: string
-    property_check_control_message:
+    charging_session_property_energy:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_check_control_message'
+          $ref: '#/components/schemas/unit_energy'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_action_item:
+    diagnostics_property_low_voltage_battery_charge_level:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_action_item'
+          enum:
+            - ok
+            - deactivation_level_1
+            - deactivation_level_2
+            - deactivation_level_3
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    race_property_angle:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_angle'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    usage_property_duration:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_duration'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -3583,15 +4875,17 @@ components:
         - minor
         - patch
       type: object
-    property_charging_time_display:
+    lights_property_front_exterior_light:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - no_display
-            - display_duration
-            - no_display_duration
+            - inactive
+            - active
+            - active_with_full_beam
+            - drl
+            - automatic
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -3602,29 +4896,29 @@ components:
     crash:
       properties:
         automatic_ecall:
-          $ref: '#/components/schemas/property_enabled_state'
+          $ref: '#/components/schemas/crash_property_enabled_state'
           description: Automatic emergency call enabled state
         impact_zone:
           description: Impact zone of the crash
           items:
-            $ref: '#/components/schemas/property_impact_zone'
+            $ref: '#/components/schemas/crash_property_impact_zone'
           type: array
         incidents:
           description: Incidents
           items:
-            $ref: '#/components/schemas/property_crash_incident'
+            $ref: '#/components/schemas/crash_property_crash_incident'
           type: array
         severity:
-          $ref: '#/components/schemas/property_uinteger'
+          $ref: '#/components/schemas/crash_property_uinteger'
           description: Severity of the crash (from 0 to 7 - very high severity)
         status:
-          $ref: '#/components/schemas/property_status'
+          $ref: '#/components/schemas/crash_property_status'
           description: The system effect an inpact had on the vehicle.
         tipped_state:
-          $ref: '#/components/schemas/property_tipped_state'
+          $ref: '#/components/schemas/crash_property_tipped_state'
           description: Tipped state
         type:
-          $ref: '#/components/schemas/property_type'
+          $ref: '#/components/schemas/crash_property_type'
           description: Type
     unit_illuminance:
       additionalProperties: false
@@ -3642,30 +4936,46 @@ components:
     cruise_control:
       properties:
         acc_target_speed:
-          $ref: '#/components/schemas/property_speed'
+          $ref: '#/components/schemas/cruise_control_property_speed'
           description: The target speed of the Adaptive Cruise Control
         adaptive_cruise_control:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/cruise_control_property_active_state'
           description: Adaptive Cruise Control
         cruise_control:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/cruise_control_property_active_state'
           description: Cruise control
         limiter:
-          $ref: '#/components/schemas/property_limiter'
+          $ref: '#/components/schemas/cruise_control_property_limiter'
           description: Limiter
         target_speed:
-          $ref: '#/components/schemas/property_speed'
+          $ref: '#/components/schemas/cruise_control_property_speed'
           description: The target speed
-    property_flashers:
+    seats_property_person_detected:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_person_detected'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_battery_temperature_control_demand:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - inactive
-            - emergency_flasher_active
-            - left_flasher_active
-            - right_flasher_active
+            - high_cooling
+            - medium_cooling
+            - low_cooling
+            - no_temperature_requirement
+            - low_heating
+            - medium_heating
+            - high_heating
+            - circulation_requirement
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -3673,24 +4983,26 @@ components:
           format: date-time
           type: string
       type: object
-    property_active_selected_state:
+    hood_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_active_selected_state'
+          maxLength: 17
+          minLength: 17
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_brake_service_due_date:
+    charging_property_active_state:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_brake_service_due_date'
+          $ref: '#/components/schemas/custom_type_active_state'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -3729,24 +5041,24 @@ components:
         - status
         - system
       type: object
-    property_driving_mode_energy_consumption:
+    charging_property_driving_mode_phev:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_driving_mode_energy_consumption'
+          $ref: '#/components/schemas/custom_type_driving_mode_phev'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_electric_current:
+    diagnostics_property_angular_velocity:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/unit_electric_current'
+          $ref: '#/components/schemas/unit_angular_velocity'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -3763,17 +5075,38 @@ components:
         - thermic
         - hybrid_parallel
       type: string
-    property_parking_light_status:
+    diagnostics_property_trouble_code:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - 'off'
-            - left
-            - right
-            - both
+          $ref: '#/components/schemas/custom_type_trouble_code'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
           type: string
+      type: object
+    power_takeoff_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    diagnostics_property_tire_temperature:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_tire_temperature'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -3783,36 +5116,24 @@ components:
     remote_control:
       properties:
         angle:
-          $ref: '#/components/schemas/property_angle'
+          $ref: '#/components/schemas/remote_control_property_angle'
           description: Wheel base angle
         control_mode:
-          $ref: '#/components/schemas/property_control_mode'
+          $ref: '#/components/schemas/remote_control_property_control_mode'
           description: Control mode
-    property_person_detected:
+    offroad_property_percentage:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_person_detected'
+          $ref: '#/components/schemas/custom_type_percentage'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_reduction_time:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_reduction_time'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_on_off_state:
+    adas_property_on_off_state:
       additionalProperties: false
       minProperties: 1
       properties:
@@ -3824,12 +5145,87 @@ components:
           format: date-time
           type: string
       type: object
-    property_trouble_code:
+    crash_property_impact_zone:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_trouble_code'
+          enum:
+            - pedestrian_protection
+            - rollover
+            - rear_passenger_side
+            - rear_driver_side
+            - side_passenger_side
+            - side_driver_side
+            - front_passenger_side
+            - front_driver_side
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    adas_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    notifications_property_action_item:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_action_item'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    cruise_control_property_active_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_active_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_session_property_active_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_active_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_smart_charging_option:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - price_optimized
+            - renewable_energy
+            - co2_optimized
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -3851,53 +5247,88 @@ components:
         - id
         - key_value
       type: object
+    seats_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    lights_property_parking_light_status:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - 'off'
+            - left
+            - right
+            - both
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     charging_session:
       properties:
         business_errors:
           description: Business errors
           items:
-            $ref: '#/components/schemas/property_string'
+            $ref: '#/components/schemas/charging_session_property_string'
           type: array
         calculated_energy_charged:
-          $ref: '#/components/schemas/property_energy'
+          $ref: '#/components/schemas/charging_session_property_energy'
           description: Calculated amount of energy charged during the session
         charging_cost:
-          $ref: '#/components/schemas/property_charging_cost'
+          $ref: '#/components/schemas/charging_session_property_charging_cost'
           description: Charging cost information
         displayed_start_state_of_charge:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/charging_session_property_percentage'
           description: Displayed state of charge at start to the driver
         displayed_state_of_charge:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/charging_session_property_percentage'
           description: Displayed state of charge to the driver
         end_time:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/charging_session_property_timestamp'
           description: End time of the charging session
         energy_charged:
-          $ref: '#/components/schemas/property_energy'
+          $ref: '#/components/schemas/charging_session_property_energy'
           description: Energy charged during the session
         location:
-          $ref: '#/components/schemas/property_charging_location'
+          $ref: '#/components/schemas/charging_session_property_charging_location'
           description: Charging location address
         odometer:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/charging_session_property_length'
           description: The vehicle odometer value in a given units
         preconditioning_state:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/charging_session_property_active_state'
           description: Preconditioning is active or not
         public_charging_points:
           description: Matching public charging points.
           items:
-            $ref: '#/components/schemas/property_charging_point'
+            $ref: '#/components/schemas/charging_session_property_charging_point'
           type: array
         start_time:
-          $ref: '#/components/schemas/property_timestamp'
+          $ref: '#/components/schemas/charging_session_property_timestamp'
           description: Start time of the charging session
         time_zone:
-          $ref: '#/components/schemas/property_string'
+          $ref: '#/components/schemas/charging_session_property_string'
           description: Time zone of the charging session
         total_charging_duration:
-          $ref: '#/components/schemas/property_duration'
+          $ref: '#/components/schemas/charging_session_property_duration'
           description: Total time charging was active during the session
     custom_type_charging_location:
       additionalProperties: false
@@ -3920,21 +5351,35 @@ components:
     light_conditions:
       properties:
         inside_light:
-          $ref: '#/components/schemas/property_illuminance'
+          $ref: '#/components/schemas/light_conditions_property_illuminance'
           description: Measured inside illuminance
         outside_light:
-          $ref: '#/components/schemas/property_illuminance'
+          $ref: '#/components/schemas/light_conditions_property_illuminance'
           description: Measured outside illuminance
     honk_horn_flash_lights:
       properties:
         flashers:
-          $ref: '#/components/schemas/property_flashers'
+          $ref: '#/components/schemas/honk_horn_flash_lights_property_flashers'
           description: Flashers
     parking_brake:
       properties:
         status:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/parking_brake_property_active_state'
           description: Status
+    theft_alarm_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_coordinates:
       additionalProperties: false
       description: Coordinates
@@ -3948,21 +5393,6 @@ components:
       required:
         - latitude
         - longitude
-      type: object
-    property_fuel_level_accuracy:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - measured
-            - calculated
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
       type: object
     custom_type_weekday_time:
       additionalProperties: false
@@ -3979,26 +5409,115 @@ components:
         - weekday
         - time
       type: object
-    property_driving_mode_phev:
+    charging_property_starter_battery_state:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_driving_mode_phev'
+          enum:
+            - red
+            - yellow
+            - green
+            - orange
+            - green_yellow
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_vehicle_moving:
+    windscreen_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_battery_led:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - not_moving
-            - moving
+            - no_colour
+            - white
+            - yellow
+            - green
+            - red
+            - yellow_pulsing
+            - green_pulsing
+            - red_pulsing
+            - green_red_pulsing
+            - green_flashing
+            - initialising
+            - error
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    engine_property_preconditioning_error:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - low_fuel
+            - low_battery
+            - quota_exceeded
+            - heater_failure
+            - component_failure
+            - open_or_unlocked
+            - ok
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    rooftop_control_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    cruise_control_property_limiter:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - not_set
+            - higher_speed_requested
+            - lower_speed_requested
+            - speed_fixed
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -4023,191 +5542,238 @@ components:
         - unit
         - value
       type: object
-    usage:
-      properties:
-        recuperation_power:
-          $ref: '#/components/schemas/property_power'
-          description: Recuperation energy of the drivetrain.
-        electric_duration_since_reset:
-          $ref: '#/components/schemas/property_duration'
-          description: Duration of travelling using electricity since reset
-        average_weekly_distance_long_run:
-          $ref: '#/components/schemas/property_length'
-          description: Average weekyl distance over long term
-        driving_modes_energy_consumptions:
-          description: Driving modes energy consumptions
-          items:
-            $ref: '#/components/schemas/property_driving_mode_energy_consumption'
-          type: array
-        electric_distance_last_trip:
-          $ref: '#/components/schemas/property_length'
-          description: Distance travelled with electricity in last trip
-        average_weekly_distance:
-          $ref: '#/components/schemas/property_length'
-          description: Average weekly distance
-        last_trip_battery_regenerated:
-          $ref: '#/components/schemas/property_percentage'
-          description: Estimated electrical charge (in %) that was recovered through regeneration during a trip.
-        rapid_deceleration_grade:
-          $ref: '#/components/schemas/property_grade'
-          description: Grade given for rapid deceleration over time
-        fuel_consumption_rate_last_trip:
-          $ref: '#/components/schemas/property_fuel_efficiency'
-          description: Liquid fuel consumption rate during last trip
-        rapid_acceleration_grade:
-          $ref: '#/components/schemas/property_grade'
-          description: Grade given for rapid acceleration over time
-        eco_score_constant:
-          $ref: '#/components/schemas/property_percentage'
-          description: Eco-score rating constant
-        driving_duration_last_trip:
-          $ref: '#/components/schemas/property_duration'
-          description: Duration of last trip
-        electric_consumption_average:
-          $ref: '#/components/schemas/property_energy_efficiency'
-          description: Average electric energy consumption calculated based on the last 20km
-        acceleration_durations:
-          description: Durations of normal or other accelerations.
-          items:
-            $ref: '#/components/schemas/property_acceleration_duration'
-          type: array
-        current_fuel_consumption:
-          $ref: '#/components/schemas/property_fuel_efficiency'
-          description: Current fuel consumption
-        last_trip_energy_consumption:
-          $ref: '#/components/schemas/property_energy'
-          description: Energy consumption in the last trip
-        electric_consumption_rate_since_start:
-          $ref: '#/components/schemas/property_energy_efficiency'
-          description: Electric energy consumption rate since the start of a trip
-        fuel_consumption_rate_since_reset:
-          $ref: '#/components/schemas/property_fuel_efficiency'
-          description: Liquid fuel consumption rate since reset
-        average_speed:
-          $ref: '#/components/schemas/property_speed'
-          description: Average speed at data collection.
-        trip_meters:
-          description: Independent meter that can be reset at any time by the driver
-          items:
-            $ref: '#/components/schemas/property_trip_meter'
-          type: array
-        average_speed_since_reset:
-          $ref: '#/components/schemas/property_speed'
-          description: Average speed since reset
-        last_trip_date:
-          $ref: '#/components/schemas/property_timestamp'
-          description: The last trip date
-        last_trip_average_energy_recuperation:
-          $ref: '#/components/schemas/property_energy_efficiency'
-          description: Energy recuperation rate for last trip
-        last_trip_fuel_consumption:
-          $ref: '#/components/schemas/property_volume'
-          description: Fuel consumption in the last trip
-        driving_duration_since_reset:
-          $ref: '#/components/schemas/property_duration'
-          description: Duration of travelling since reset
-        electric_consumption_rate_since_reset:
-          $ref: '#/components/schemas/property_energy_efficiency'
-          description: Electric energy consumption rate since a reset
-        eco_score_free_wheel:
-          $ref: '#/components/schemas/property_percentage'
-          description: Eco-score rating for free-wheeling
-        driving_modes_activation_periods:
-          description: Driving modes activation periods
-          items:
-            $ref: '#/components/schemas/property_driving_mode_activation_period'
-          type: array
-        fuel_distance_since_reset:
-          $ref: '#/components/schemas/property_length'
-          description: Distance travelled with (liquid) fuel since reset
-        eco_score_bonus_range:
-          $ref: '#/components/schemas/property_length'
-          description: Eco-score bonus range
-        acceleration_evaluation:
-          $ref: '#/components/schemas/property_percentage'
-          description: Acceleration evaluation percentage
-        electric_distance_since_reset:
-          $ref: '#/components/schemas/property_length'
-          description: Distance travelled with electricity since reset
-        average_fuel_consumption:
-          $ref: '#/components/schemas/property_fuel_efficiency'
-          description: Average fuel consumption for current trip
-        distance_over_time:
-          $ref: '#/components/schemas/property_distance_over_time'
-          description: Distance driven over a given time period
-        mileage_after_last_trip:
-          $ref: '#/components/schemas/property_length'
-          deprecated: true
-          description: Mileage after the last trip
-        eco_score_total:
-          $ref: '#/components/schemas/property_percentage'
-          description: Overall eco-score rating
-        braking_evaluation:
-          $ref: '#/components/schemas/property_percentage'
-          description: Braking evaluation percentage
-        odometer_after_last_trip:
-          $ref: '#/components/schemas/property_length'
-          description: Odometer after the last trip
-        last_trip_electric_portion:
-          $ref: '#/components/schemas/property_percentage'
-          description: Portion of the last trip used in electric mode
-        average_speed_last_trip:
-          $ref: '#/components/schemas/property_speed'
-          description: Average speed during last trip
-        electric_duration_last_trip:
-          $ref: '#/components/schemas/property_duration'
-          description: Duration of travelling using electricity during last trip
-        fuel_distance_last_trip:
-          $ref: '#/components/schemas/property_length'
-          description: Distance travelled with (liquid) fuel during last trip
-        safety_driving_score:
-          $ref: '#/components/schemas/property_percentage'
-          description: Safety driving score as percentage
-        driving_style_evaluation:
-          $ref: '#/components/schemas/property_percentage'
-          description: Driving style evaluation percentage
-        late_night_grade:
-          $ref: '#/components/schemas/property_grade'
-          description: Grade given for late night driving over time
-        last_trip_battery_remaining:
-          $ref: '#/components/schemas/property_percentage'
-          description: Battery % remaining after last trip
-    property_length:
+    diagnostics_property_temperature:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/unit_length'
+          $ref: '#/components/schemas/unit_temperature'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_condition_based_service:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_condition_based_service'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_charge_mode:
+    windscreen_property_windscreen_damage:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - immediate
-            - timer_based
-            - inductive
-            - conductive
-            - push_button
+            - no_impact_detected
+            - impact_but_no_damage_detected
+            - damage_smaller_than_1_inch
+            - damage_larger_than_1_inch
           type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    chassis_settings_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    usage:
+      properties:
+        recuperation_power:
+          $ref: '#/components/schemas/usage_property_power'
+          description: Recuperation energy of the drivetrain.
+        electric_duration_since_reset:
+          $ref: '#/components/schemas/usage_property_duration'
+          description: Duration of travelling using electricity since reset
+        average_weekly_distance_long_run:
+          $ref: '#/components/schemas/usage_property_length'
+          description: Average weekyl distance over long term
+        driving_modes_energy_consumptions:
+          description: Driving modes energy consumptions
+          items:
+            $ref: '#/components/schemas/usage_property_driving_mode_energy_consumption'
+          type: array
+        electric_distance_last_trip:
+          $ref: '#/components/schemas/usage_property_length'
+          description: Distance travelled with electricity in last trip
+        average_weekly_distance:
+          $ref: '#/components/schemas/usage_property_length'
+          description: Average weekly distance
+        last_trip_battery_regenerated:
+          $ref: '#/components/schemas/usage_property_percentage'
+          description: Estimated electrical charge (in %) that was recovered through regeneration during a trip.
+        rapid_deceleration_grade:
+          $ref: '#/components/schemas/usage_property_grade'
+          description: Grade given for rapid deceleration over time
+        fuel_consumption_rate_last_trip:
+          $ref: '#/components/schemas/usage_property_fuel_efficiency'
+          description: Liquid fuel consumption rate during last trip
+        rapid_acceleration_grade:
+          $ref: '#/components/schemas/usage_property_grade'
+          description: Grade given for rapid acceleration over time
+        eco_score_constant:
+          $ref: '#/components/schemas/usage_property_percentage'
+          description: Eco-score rating constant
+        driving_duration_last_trip:
+          $ref: '#/components/schemas/usage_property_duration'
+          description: Duration of last trip
+        electric_consumption_average:
+          $ref: '#/components/schemas/usage_property_energy_efficiency'
+          description: Average electric energy consumption calculated based on the last 20km
+        acceleration_durations:
+          description: Durations of normal or other accelerations.
+          items:
+            $ref: '#/components/schemas/usage_property_acceleration_duration'
+          type: array
+        current_fuel_consumption:
+          $ref: '#/components/schemas/usage_property_fuel_efficiency'
+          description: Current fuel consumption
+        last_trip_energy_consumption:
+          $ref: '#/components/schemas/usage_property_energy'
+          description: Energy consumption in the last trip
+        electric_consumption_rate_since_start:
+          $ref: '#/components/schemas/usage_property_energy_efficiency'
+          description: Electric energy consumption rate since the start of a trip
+        fuel_consumption_rate_since_reset:
+          $ref: '#/components/schemas/usage_property_fuel_efficiency'
+          description: Liquid fuel consumption rate since reset
+        average_speed:
+          $ref: '#/components/schemas/usage_property_speed'
+          description: Average speed at data collection.
+        trip_meters:
+          description: Independent meter that can be reset at any time by the driver
+          items:
+            $ref: '#/components/schemas/usage_property_trip_meter'
+          type: array
+        average_speed_since_reset:
+          $ref: '#/components/schemas/usage_property_speed'
+          description: Average speed since reset
+        last_trip_date:
+          $ref: '#/components/schemas/usage_property_timestamp'
+          description: The last trip date
+        last_trip_average_energy_recuperation:
+          $ref: '#/components/schemas/usage_property_energy_efficiency'
+          description: Energy recuperation rate for last trip
+        last_trip_fuel_consumption:
+          $ref: '#/components/schemas/usage_property_volume'
+          description: Fuel consumption in the last trip
+        driving_duration_since_reset:
+          $ref: '#/components/schemas/usage_property_duration'
+          description: Duration of travelling since reset
+        electric_consumption_rate_since_reset:
+          $ref: '#/components/schemas/usage_property_energy_efficiency'
+          description: Electric energy consumption rate since a reset
+        eco_score_free_wheel:
+          $ref: '#/components/schemas/usage_property_percentage'
+          description: Eco-score rating for free-wheeling
+        driving_modes_activation_periods:
+          description: Driving modes activation periods
+          items:
+            $ref: '#/components/schemas/usage_property_driving_mode_activation_period'
+          type: array
+        fuel_distance_since_reset:
+          $ref: '#/components/schemas/usage_property_length'
+          description: Distance travelled with (liquid) fuel since reset
+        eco_score_bonus_range:
+          $ref: '#/components/schemas/usage_property_length'
+          description: Eco-score bonus range
+        acceleration_evaluation:
+          $ref: '#/components/schemas/usage_property_percentage'
+          description: Acceleration evaluation percentage
+        electric_distance_since_reset:
+          $ref: '#/components/schemas/usage_property_length'
+          description: Distance travelled with electricity since reset
+        average_fuel_consumption:
+          $ref: '#/components/schemas/usage_property_fuel_efficiency'
+          description: Average fuel consumption for current trip
+        distance_over_time:
+          $ref: '#/components/schemas/usage_property_distance_over_time'
+          description: Distance driven over a given time period
+        mileage_after_last_trip:
+          $ref: '#/components/schemas/usage_property_length'
+          deprecated: true
+          description: Mileage after the last trip
+        eco_score_total:
+          $ref: '#/components/schemas/usage_property_percentage'
+          description: Overall eco-score rating
+        braking_evaluation:
+          $ref: '#/components/schemas/usage_property_percentage'
+          description: Braking evaluation percentage
+        odometer_after_last_trip:
+          $ref: '#/components/schemas/usage_property_length'
+          description: Odometer after the last trip
+        last_trip_electric_portion:
+          $ref: '#/components/schemas/usage_property_percentage'
+          description: Portion of the last trip used in electric mode
+        average_speed_last_trip:
+          $ref: '#/components/schemas/usage_property_speed'
+          description: Average speed during last trip
+        electric_duration_last_trip:
+          $ref: '#/components/schemas/usage_property_duration'
+          description: Duration of travelling using electricity during last trip
+        fuel_distance_last_trip:
+          $ref: '#/components/schemas/usage_property_length'
+          description: Distance travelled with (liquid) fuel during last trip
+        safety_driving_score:
+          $ref: '#/components/schemas/usage_property_percentage'
+          description: Safety driving score as percentage
+        driving_style_evaluation:
+          $ref: '#/components/schemas/usage_property_percentage'
+          description: Driving style evaluation percentage
+        late_night_grade:
+          $ref: '#/components/schemas/usage_property_grade'
+          description: Grade given for late night driving over time
+        last_trip_battery_remaining:
+          $ref: '#/components/schemas/usage_property_percentage'
+          description: Battery % remaining after last trip
+    theft_alarm_property_active_selected_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_active_selected_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_electric_current:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_electric_current'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -4248,6 +5814,18 @@ components:
         - text
         - description
       type: object
+    climate_property_percentage:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_percentage'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_availability:
       additionalProperties: false
       description: Availability
@@ -4277,6 +5855,38 @@ components:
         - rate_limit
         - applies_per
       type: object
+    diagnostics_property_engine_oil_pressure_level:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - low
+            - normal
+            - high
+            - low_soft
+            - low_hard
+            - no_sensor
+            - system_fault
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    usage_property_distance_over_time:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_distance_over_time'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_zone:
       additionalProperties: false
       description: Zone
@@ -4291,17 +5901,64 @@ components:
         - horizontal
         - vertical
       type: object
-    property_limiter:
+    doors_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    rooftop_control_property_convertible_roof_state:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - not_set
-            - higher_speed_requested
-            - lower_speed_requested
-            - speed_fixed
+            - closed
+            - open
+            - emergency_locked
+            - closed_secured
+            - open_secured
+            - hard_top_mounted
+            - intermediate_position
+            - loading_position
+            - loading_position_immediate
           type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    trunk_property_lock_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_lock_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    light_conditions_property_illuminance:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_illuminance'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -4325,29 +5982,13 @@ components:
         - unit
         - value
       type: object
-    property_ignition_state:
+    trunk_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_ignition_state'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_station_status:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - not_compatible
-            - not_detected
-            - digital_communication_established
-            - digital_communication_ended
-            - station_ready
+          maxLength: 17
+          minLength: 17
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -4355,12 +5996,24 @@ components:
           format: date-time
           type: string
       type: object
-    property_volume:
+    cruise_control_property_speed:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/unit_volume'
+          $ref: '#/components/schemas/unit_speed'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    engine_property_enabled_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_enabled_state'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -4381,46 +6034,35 @@ components:
         request_id:
           description: The request tracking id. Provide request_id when facing issue
           type: string
-    property_bulb_failures:
+    parking_brake_property_nonce:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - turn_signal_left
-            - turn_signal_right
-            - low_beam
-            - low_beam_left
-            - low_beam_right
-            - high_beam
-            - high_beam_left
-            - high_beam_right
-            - fog_light_front
-            - fog_light_rear
-            - stop
-            - position
-            - day_running
-            - trailer_turn
-            - trailer_turn_left
-            - trailer_turn_right
-            - trailer_stop
-            - trailer_electrical_failure
-            - multiple
-          type: string
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_current_type:
+    lights_property_switch_position:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - alternating_current
-            - direct_current
+            - automatic
+            - dipped_headlights
+            - parking_light_right
+            - parking_light_left
+            - sidelights
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -4442,24 +6084,70 @@ components:
         - unit
         - value
       type: object
-    property_tire_temperature:
+    usage_property_grade:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_tire_temperature'
+          $ref: '#/components/schemas/custom_type_grade'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_tire_pressure_status:
+    maintenance_property_brake_service_remaining_distance:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_tire_pressure_status'
+          $ref: '#/components/schemas/custom_type_brake_service_remaining_distance'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    cruise_control_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    crash_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    maintenance_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -4480,12 +6168,48 @@ components:
         - location
         - state
       type: object
+    charging_property_lock_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_lock_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    engine_property_on_off_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_on_off_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_axle:
       description: Axle
       enum:
         - front
         - rear
       type: string
+    diagnostics_property_fluid_level:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_fluid_level'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_charging_cost:
       additionalProperties: false
       description: Charging cost information
@@ -4508,6 +6232,30 @@ components:
         - calculated_savings
         - simulated_immediate_charging_cost
       type: object
+    dashboard_lights_property_dashboard_light:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_dashboard_light'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    notifications_property_string:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_trip_meter:
       additionalProperties: false
       description: Independent meter that can be reset at any time by the driver
@@ -4522,12 +6270,16 @@ components:
         - id
         - distance
       type: object
-    property_trip_meter:
+    theft_alarm_property_status:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_trip_meter'
+          enum:
+            - unarmed
+            - armed
+            - triggered
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -4537,17 +6289,41 @@ components:
     messaging:
       properties:
         handle:
-          $ref: '#/components/schemas/property_string'
+          $ref: '#/components/schemas/messaging_property_string'
           description: The optional handle of message
         text:
-          $ref: '#/components/schemas/property_string'
+          $ref: '#/components/schemas/messaging_property_string'
           description: The text
-    property_illuminance:
+    doors_property_lock:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/unit_illuminance'
+          $ref: '#/components/schemas/custom_type_lock'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    chassis_settings_property_driving_mode:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_driving_mode'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    trunk_property_position:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_position'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -4576,23 +6352,6 @@ components:
       required:
         - reason
         - description
-      type: object
-    property_acoustic_limit:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - no_action
-            - automatic
-            - unlimited
-            - limited
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
       type: object
     unit_angle:
       additionalProperties: false
@@ -4627,60 +6386,49 @@ components:
         - lpg
         - hybrid
       type: string
-    property_battery_status:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - inactive
-            - active
-            - balancing
-            - external_load
-            - load
-            - error
-            - initialising
-            - conditioning
-          type: string
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     rooftop_control:
       properties:
         convertible_roof_state:
-          $ref: '#/components/schemas/property_convertible_roof_state'
+          $ref: '#/components/schemas/rooftop_control_property_convertible_roof_state'
           description: Convertible roof state
         dimming:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/rooftop_control_property_percentage'
           description: 1.0 (100%) is opaque, 0.0 (0%) is transparent
         position:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/rooftop_control_property_percentage'
           description: 1.0 (100%) is fully open, 0.0 (0%) is closed
         sunroof_rain_event:
-          $ref: '#/components/schemas/property_sunroof_rain_event'
+          $ref: '#/components/schemas/rooftop_control_property_sunroof_rain_event'
           description: Sunroof event happened in case of rain
         sunroof_state:
-          $ref: '#/components/schemas/property_sunroof_state'
+          $ref: '#/components/schemas/rooftop_control_property_sunroof_state'
           description: Sunroof state
         sunroof_tilt_state:
-          $ref: '#/components/schemas/property_sunroof_tilt_state'
+          $ref: '#/components/schemas/rooftop_control_property_sunroof_tilt_state'
           description: Sunroof tilt state
         tilt_position:
-          $ref: '#/components/schemas/property_percentage'
+          $ref: '#/components/schemas/rooftop_control_property_percentage'
           description: 1.0 (100%) is fully tilted, 0.0 (0%) is not
-    property_sunroof_rain_event:
+    charging_property_duration:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_duration'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    diagnostics_property_fuel_level_accuracy:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - no_event
-            - in_stroke_position_because_of_rain
-            - automatically_in_stroke_position
-            - timer
+            - measured
+            - calculated
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -4688,27 +6436,27 @@ components:
           format: date-time
           type: string
       type: object
-    property_angular_velocity:
+    weather_conditions_property_percentage:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/unit_angular_velocity'
+          $ref: '#/components/schemas/custom_type_percentage'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_departure_time_display:
+    hood_property_position:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - no_display
-            - reachable
-            - not_reachable
+            - closed
+            - open
+            - intermediate
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -4716,12 +6464,15 @@ components:
           format: date-time
           type: string
       type: object
-    property_window_position:
+    power_takeoff_property_engaged:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_window_position'
+          enum:
+            - not_engaged
+            - engaged
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -4763,6 +6514,45 @@ components:
         - component
         - cleaning
       type: object
+    crash_property_type:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - pedestrian
+            - non_pedestrian
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    maintenance_property_duration:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_duration'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    usage_property_length:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_length'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_temperature_extreme:
       additionalProperties: false
       description: Temperature extreme
@@ -4783,51 +6573,48 @@ components:
     lights:
       properties:
         ambient_light_colour:
-          $ref: '#/components/schemas/property_rgb_colour'
+          $ref: '#/components/schemas/lights_property_rgb_colour'
           description: Ambient light colour
         emergency_brake_light:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/lights_property_active_state'
           description: Emergency brake light
         fog_lights:
           description: Fog lights
           items:
-            $ref: '#/components/schemas/property_light'
+            $ref: '#/components/schemas/lights_property_light'
           type: array
         front_exterior_light:
-          $ref: '#/components/schemas/property_front_exterior_light'
+          $ref: '#/components/schemas/lights_property_front_exterior_light'
           description: Front exterior light
         interior_lights:
           description: Interior lights
           items:
-            $ref: '#/components/schemas/property_light'
+            $ref: '#/components/schemas/lights_property_light'
           type: array
         parking_light_status:
-          $ref: '#/components/schemas/property_parking_light_status'
+          $ref: '#/components/schemas/lights_property_parking_light_status'
           description: Indicates the status of the parking light.
         reading_lamps:
           description: Reading lamps
           items:
-            $ref: '#/components/schemas/property_reading_lamp'
+            $ref: '#/components/schemas/lights_property_reading_lamp'
           type: array
         rear_exterior_light:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/lights_property_active_state'
           description: Rear exterior light
         reverse_light:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/lights_property_active_state'
           description: Reverse light
         switch_position:
-          $ref: '#/components/schemas/property_switch_position'
+          $ref: '#/components/schemas/lights_property_switch_position'
           description: Position of the rotary light switch
-    property_teleservice_availability:
+    engine_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - pending
-            - idle
-            - successful
-            - error
+          maxLength: 17
+          minLength: 17
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -4835,12 +6622,48 @@ components:
           format: date-time
           type: string
       type: object
-    property_energy_efficiency:
+    charging_property_vin:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/unit_energy_efficiency'
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    ignition_property_ignition_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_ignition_state'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    race_property_drivetrain_state:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - inactive
+            - race_start_preparation
+            - race_start
+            - start
+            - comfort_start
+            - start_idle_run_control
+            - ready_for_overpressing
+            - low_speed_mode
+            - e_launch
+          type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -4879,35 +6702,30 @@ components:
         - severity
         - repairs
       type: object
-    property_last_warning_reason:
+    vehicle_location_property_nonce:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - no_alarm
-            - basic_alarm
-            - door_front_left
-            - door_front_right
-            - door_rear_left
-            - door_rear_right
-            - hood
-            - trunk
-            - common_alm_in
-            - panic
-            - glovebox
-            - center_box
-            - rear_box
-            - sensor_vta
-            - its
-            - its_slv
-            - tps
-            - horn
-            - hold_com
-            - remote
-            - unknown
-            - siren
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
           type: string
+      type: object
+    charging_property_temperature:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_temperature'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -4931,6 +6749,40 @@ components:
           description: The request tracking id. Provide request_id when facing issue
           example: e4828bf1-8687-4f7b-b8c7-6c4223e2b842
           type: string
+    light_conditions_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_charging_time_display:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          enum:
+            - no_display
+            - display_duration
+            - no_display_duration
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     unit_volume:
       additionalProperties: false
       properties:
@@ -4972,46 +6824,48 @@ components:
         - state
         - time
       type: object
-    property_front_exterior_light:
+    usage_property_power:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - inactive
-            - active
-            - active_with_full_beam
-            - drl
-            - automatic
-          type: string
+          $ref: '#/components/schemas/unit_power'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_sport_chrono:
+    diagnostics_property_tire_pressure:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - inactive
-            - active
-            - reset
-          type: string
+          $ref: '#/components/schemas/custom_type_tire_pressure'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_lane_keep_assist_state:
+    charging_property_departure_time:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_lane_keep_assist_state'
+          $ref: '#/components/schemas/custom_type_departure_time'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    maintenance_property_service_status:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_service_status'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -5035,14 +6889,24 @@ components:
         - type
         - value
       type: object
-    property_vin:
+    theft_alarm_property_triggered:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          maxLength: 17
-          minLength: 17
+          $ref: '#/components/schemas/custom_type_triggered'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
           type: string
+      type: object
+    charging_property_percentage:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_percentage'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -5080,58 +6944,94 @@ components:
         request_id:
           description: The request tracking id. Provide request_id when facing issue
           type: string
-    property_gear_mode:
+    charging_property_power:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - manual
-            - park
-            - reverse
-            - neutral
-            - drive
-            - low_gear
-            - sport
-          type: string
+          $ref: '#/components/schemas/unit_power'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_windscreen_needs_replacement:
+    windscreen_property_zone:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          enum:
-            - unknown
-            - no_replacement_needed
-            - replacement_needed
-          type: string
+          $ref: '#/components/schemas/custom_type_zone'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_event_type:
+    climate_property_temperature:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_temperature'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    windows_property_window_position:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_window_position'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    vehicle_location_property_length:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_length'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    race_property_pressure:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/unit_pressure'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_charging_end_reason:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
           enum:
-            - idle
-            - front_left
-            - front_middle
-            - front_right
-            - right
-            - rear_right
-            - rear_middle
-            - rear_left
-            - left
             - unknown
+            - goal_reached
+            - requested_by_driver
+            - connector_removed
+            - powergrid_failed
+            - hv_system_failure
+            - charging_station_failure
+            - parking_lock_failed
+            - no_parking_lock
+            - signal_invalid
           type: string
         failure:
           $ref: '#/components/schemas/custom_type_failure'
@@ -5167,12 +7067,12 @@ components:
         - location
         - pressure
       type: object
-    property_grade:
+    usage_property_fuel_efficiency:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_grade'
+          $ref: '#/components/schemas/unit_fuel_efficiency'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -5182,102 +7082,80 @@ components:
     engine:
       properties:
         limp_mode:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/engine_property_active_state'
           description: Indicates wheter the engine is in fail-safe mode.
         preconditioning_active:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/engine_property_active_state'
           description: Pre-conditioning is running.
         preconditioning_enabled:
-          $ref: '#/components/schemas/property_enabled_state'
+          $ref: '#/components/schemas/engine_property_enabled_state'
           description: Use of the engine pre-conditioning is enabled.
         preconditioning_error:
-          $ref: '#/components/schemas/property_preconditioning_error'
+          $ref: '#/components/schemas/engine_property_preconditioning_error'
           description: Reason for not carrying out pre-conditioning.
         preconditioning_remaining_time:
-          $ref: '#/components/schemas/property_duration'
+          $ref: '#/components/schemas/engine_property_duration'
           description: Remaining time of pre-conditioning.
         preconditioning_status:
-          $ref: '#/components/schemas/property_preconditioning_status'
+          $ref: '#/components/schemas/engine_property_preconditioning_status'
           description: Status of the pre-conditioning system.
         start_stop_enabled:
-          $ref: '#/components/schemas/property_enabled_state'
+          $ref: '#/components/schemas/engine_property_enabled_state'
           description: Indicates if the automatic start-stop system is enabled or not
         start_stop_state:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/engine_property_active_state'
           description: Indicates wheter the start-stop system is currently active or not
         status:
-          $ref: '#/components/schemas/property_on_off_state'
+          $ref: '#/components/schemas/engine_property_on_off_state'
           description: Status
     adas:
       properties:
         alertness_system_status:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/adas_property_active_state'
           description: Indicates if the driver alertness warning is active or inactive.
         automated_parking_brake:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/adas_property_active_state'
           description: Automatic brake state
         blind_spot_warning_state:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/adas_property_active_state'
           description: Indicates whether the blind spot warning system is active or not.
         blind_spot_warning_system:
-          $ref: '#/components/schemas/property_on_off_state'
+          $ref: '#/components/schemas/adas_property_on_off_state'
           description: Indicates whether the blind spot warning system is turned on or not.
         blind_spot_warning_system_coverage:
-          $ref: '#/components/schemas/property_blind_spot_warning_system_coverage'
+          $ref: '#/components/schemas/adas_property_blind_spot_warning_system_coverage'
           description: Blind spot warning system coverage.
         forward_collision_warning_system:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/adas_property_active_state'
           description: Indicates whether the forward collision warning system is active or inactive.
         lane_keep_assist_system:
-          $ref: '#/components/schemas/property_on_off_state'
+          $ref: '#/components/schemas/adas_property_on_off_state'
           description: Indicates if the lane keep assist system is turned on or not.
         lane_keep_assists_states:
           description: Lane keeping assist state indicating the vehicle is actively controlling the wheels.
           items:
-            $ref: '#/components/schemas/property_lane_keep_assist_state'
+            $ref: '#/components/schemas/adas_property_lane_keep_assist_state'
           type: array
         launch_control:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/adas_property_active_state'
           description: State of launch control activation.
         park_assists:
           description: If the alarm is active and the driver has muted or not park assists.
           items:
-            $ref: '#/components/schemas/property_park_assist'
+            $ref: '#/components/schemas/adas_property_park_assist'
           type: array
         rear_cross_warning_system:
-          $ref: '#/components/schemas/property_active_state'
+          $ref: '#/components/schemas/adas_property_active_state'
           description: Indicates whether the rear cross warning system is active or not.
         status:
-          $ref: '#/components/schemas/property_on_off_state'
+          $ref: '#/components/schemas/adas_property_on_off_state'
           description: Indicates whether the driver assistance system is active or not.
-    property_active_state:
+    maintenance_property_length:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_active_state'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_convertible_roof_state:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - closed
-            - open
-            - emergency_locked
-            - closed_secured
-            - open_secured
-            - hard_top_mounted
-            - intermediate_position
-            - loading_position
-            - loading_position_immediate
-          type: string
+          $ref: '#/components/schemas/unit_length'
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -5287,81 +7165,47 @@ components:
     chassis_settings:
       properties:
         current_chassis_position:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/chassis_settings_property_length'
           description: The chassis position calculated from the lowest point
         current_spring_rates:
           description: The current values for the spring rates
           items:
-            $ref: '#/components/schemas/property_spring_rate'
+            $ref: '#/components/schemas/chassis_settings_property_spring_rate'
           type: array
         driving_mode:
-          $ref: '#/components/schemas/property_driving_mode'
+          $ref: '#/components/schemas/chassis_settings_property_driving_mode'
           description: Driving mode
         maximum_chassis_position:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/chassis_settings_property_length'
           description: The maximum possible value for the chassis position
         maximum_spring_rates:
           description: The maximum possible values for the spring rates
           items:
-            $ref: '#/components/schemas/property_spring_rate'
+            $ref: '#/components/schemas/chassis_settings_property_spring_rate'
           type: array
         minimum_chassis_position:
-          $ref: '#/components/schemas/property_length'
+          $ref: '#/components/schemas/chassis_settings_property_length'
           description: The minimum possible value for the chassis position
         minimum_spring_rates:
           description: The minimum possible values for the spring rates
           items:
-            $ref: '#/components/schemas/property_spring_rate'
+            $ref: '#/components/schemas/chassis_settings_property_spring_rate'
           type: array
         sport_chrono:
-          $ref: '#/components/schemas/property_sport_chrono'
+          $ref: '#/components/schemas/chassis_settings_property_sport_chrono'
           description: Sport chrono
-    property_speed:
+    cruise_control_property_nonce:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/unit_speed'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_electric_potential_difference:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/unit_electric_potential_difference'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_tire_pressure:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_tire_pressure'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_sunroof_state:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          enum:
-            - closed
-            - open
-            - intermediate
-          type: string
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
@@ -5382,19 +7226,110 @@ components:
         - hour
         - minute
       type: object
-    property_acceleration_duration:
+    maintenance_property_nonce:
       additionalProperties: false
       minProperties: 1
       properties:
         data:
-          $ref: '#/components/schemas/custom_type_acceleration_duration'
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
         failure:
           $ref: '#/components/schemas/custom_type_failure'
         timestamp:
           format: date-time
           type: string
       type: object
-    property_station_displayed_status:
+    doors:
+      properties:
+        inside_locks:
+          description: Inside lock states for the given doors
+          items:
+            $ref: '#/components/schemas/doors_property_lock'
+          type: array
+        inside_locks_state:
+          $ref: '#/components/schemas/doors_property_lock_state'
+          description: Inside locks state for the whole vehicle (combines all specific lock states if available)
+        locks:
+          description: Lock states for the given doors
+          items:
+            $ref: '#/components/schemas/doors_property_lock'
+          type: array
+        locks_state:
+          $ref: '#/components/schemas/doors_property_lock_state'
+          description: Locks state for the whole vehicle (combines all specific lock states if available)
+        positions:
+          description: Door positions for the given doors
+          items:
+            $ref: '#/components/schemas/doors_property_door_position'
+          type: array
+    vehicle_location_property_vin:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          maxLength: 17
+          minLength: 17
+          type: string
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    windows_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    messaging_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    diagnostics_property_tire_pressure_status:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_tire_pressure_status'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    charging_property_station_displayed_status:
       additionalProperties: false
       minProperties: 1
       properties:
@@ -5418,65 +7353,60 @@ components:
           format: date-time
           type: string
       type: object
-    doors:
-      properties:
-        inside_locks:
-          description: Inside lock states for the given doors
-          items:
-            $ref: '#/components/schemas/property_lock'
-          type: array
-        inside_locks_state:
-          $ref: '#/components/schemas/property_lock_state'
-          description: Inside locks state for the whole vehicle (combines all specific lock states if available)
-        locks:
-          description: Lock states for the given doors
-          items:
-            $ref: '#/components/schemas/property_lock'
-          type: array
-        locks_state:
-          $ref: '#/components/schemas/property_lock_state'
-          description: Locks state for the whole vehicle (combines all specific lock states if available)
-        positions:
-          description: Door positions for the given doors
-          items:
-            $ref: '#/components/schemas/property_door_position'
-          type: array
-    property_wheel_rpm:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_wheel_rpm'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
-    property_fluid_level:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_fluid_level'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
-      type: object
     custom_type_active_state:
       description: Active state
       enum:
         - inactive
         - active
       type: string
+    race_property_brake_torque_vectoring:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_brake_torque_vectoring'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     custom_type_start_stop:
       description: Start-Stop
       enum:
         - start
         - stop
       type: string
+    charging_session_property_nonce:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          items:
+            maximum: 255
+            minimum: 0
+            type: integer
+          maxItems: 9
+          minItems: 9
+          type: array
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    windscreen_property_percentage:
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        data:
+          $ref: '#/components/schemas/custom_type_percentage'
+        failure:
+          $ref: '#/components/schemas/custom_type_failure'
+        timestamp:
+          format: date-time
+          type: string
+      type: object
     unit_length:
       additionalProperties: false
       properties:
@@ -5500,18 +7430,6 @@ components:
       required:
         - unit
         - value
-      type: object
-    property_light:
-      additionalProperties: false
-      minProperties: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/custom_type_light'
-        failure:
-          $ref: '#/components/schemas/custom_type_failure'
-        timestamp:
-          format: date-time
-          type: string
       type: object
   securitySchemes:
     VehicleDataAuth:


### PR DESCRIPTION
There was an issue with the generator that replaced "charging.get.status" specs with "crash.get.status".

With this change, we are explicitly duplicating all the properties based on the capabilities. The downside is that now all common properties like 'property_uinteger' are duplicated for all capabilities. For example, we have 'charging_property_uinteger', 'crash_property_uinteger', and so on.